### PR TITLE
Add nonce checks to quiz style and score privacy AJAX handlers

### DIFF
--- a/admin/admin-page.php
+++ b/admin/admin-page.php
@@ -79,5 +79,13 @@ function villegas_admin_quizzes_page() {
     // Encolar JS
     wp_enqueue_media();
     wp_enqueue_script('villegas-quiz-style', plugin_dir_url(__FILE__) . 'js/quiz-style.js', ['jquery'], '1.0', true);
+    wp_localize_script(
+        'villegas-quiz-style',
+        'villegasQuizStyleData',
+        [
+            'ajaxurl'  => admin_url('admin-ajax.php'),
+            'security' => wp_create_nonce('guardar_imagen_estilo_quiz'),
+        ]
+    );
 }
 

--- a/admin/js/quiz-style.js
+++ b/admin/js/quiz-style.js
@@ -1,4 +1,11 @@
 jQuery(document).ready(function($) {
+    const ajaxUrl = (typeof villegasQuizStyleData !== 'undefined' && villegasQuizStyleData.ajaxurl)
+        ? villegasQuizStyleData.ajaxurl
+        : (typeof ajaxurl !== 'undefined' ? ajaxurl : '');
+    const securityNonce = (typeof villegasQuizStyleData !== 'undefined' && villegasQuizStyleData.security)
+        ? villegasQuizStyleData.security
+        : '';
+
     $('.select-image-button').click(function(e) {
         e.preventDefault();
         const button = $(this);
@@ -19,10 +26,11 @@ jQuery(document).ready(function($) {
             previewContainer.html('<img src="' + attachment.sizes.thumbnail.url + '" style="max-width:80px;">');
 
             // Guardar por AJAX
-            $.post(ajaxurl, {
+            $.post(ajaxUrl, {
                 action: 'guardar_imagen_estilo_quiz',
                 quiz_id: quizID,
-                image_id: attachment.id
+                image_id: attachment.id,
+                security: securityNonce
             }, function(response) {
                 if (response.success) {
                     console.log('Imagen guardada');

--- a/assets/js/puntaje-privado.js
+++ b/assets/js/puntaje-privado.js
@@ -9,7 +9,8 @@ document.addEventListener('DOMContentLoaded', function () {
         console.log('Enviando AJAX:', {
             action: 'guardar_privacidad_puntaje',
             user_id: userId,
-            puntaje_privado: isPrivate ? '1' : '0'
+            puntaje_privado: isPrivate ? '1' : '0',
+            security: puntajePrivadoData.security
         });
 
         fetch(puntajePrivadoData.ajaxurl, {
@@ -19,7 +20,8 @@ document.addEventListener('DOMContentLoaded', function () {
             body: new URLSearchParams({
                 action: 'guardar_privacidad_puntaje',
                 user_id: userId,
-                puntaje_privado: isPrivate ? '1' : '0'
+                puntaje_privado: isPrivate ? '1' : '0',
+                security: puntajePrivadoData.security
             })
         })
         .then(res => res.json())

--- a/my-ld-course-override.php
+++ b/my-ld-course-override.php
@@ -230,6 +230,8 @@ function villegas_enqueue_quiz_float_fix() {
 add_action('wp_enqueue_scripts', 'villegas_enqueue_quiz_float_fix');
 
 add_action('wp_ajax_guardar_imagen_estilo_quiz', function () {
+    check_ajax_referer('guardar_imagen_estilo_quiz', 'security');
+
     if (!current_user_can('manage_options')) {
         wp_send_json_error('No autorizado');
     }
@@ -566,11 +568,12 @@ function villegas_enqueue_puntaje_privado_script() {
             '1.0',
             true
         );
-        
+
         wp_localize_script('puntaje-privado', 'puntajePrivadoData', [
             'ajaxurl' => admin_url('admin-ajax.php'),
-            'userId'  => get_current_user_id()
-        ]);        
+            'userId'  => get_current_user_id(),
+            'security' => wp_create_nonce('guardar_privacidad_puntaje'),
+        ]);
     }
 }
 
@@ -579,6 +582,8 @@ function villegas_enqueue_puntaje_privado_script() {
 add_action('wp_ajax_guardar_privacidad_puntaje', 'villegas_guardar_privacidad_puntaje');
 
 function villegas_guardar_privacidad_puntaje() {
+    check_ajax_referer('guardar_privacidad_puntaje', 'security');
+
     $user_id = isset($_POST['user_id']) ? intval($_POST['user_id']) : 0;
     $puntaje_privado = isset($_POST['puntaje_privado']) && $_POST['puntaje_privado'] === '1';
 


### PR DESCRIPTION
## Summary
- localize the quiz style admin script with a nonce and submit it via AJAX
- secure the quiz style image handler with check_ajax_referer
- add nonce handling to the score privacy flow on both the client and server

## Testing
- php -l admin/admin-page.php
- php -l my-ld-course-override.php

------
https://chatgpt.com/codex/tasks/task_e_68dee02ffc2c8332b34bf77503b98d77