### PR TITLE
Harden quiz completion email AJAX endpoints

### DIFF
--- a/assets/custom-quiz-message.js
+++ b/assets/custom-quiz-message.js
@@ -24,6 +24,13 @@ document.addEventListener("DOMContentLoaded", function () {
 
 jQuery(document).on('learndash-quiz-finished', function () {
     if (typeof quizData !== 'undefined' && quizData.type === 'final') {
+        var finalQuizNonce = quizData.finalQuizNonce || '';
+
+        if (!finalQuizNonce) {
+            console.error('No se encontró nonce para el Final Quiz. Abortando envío.');
+            return;
+        }
+
         var correctAnswers = parseInt(jQuery('.wpProQuiz_correct_answer').text(), 10);
         var totalQuestions = parseInt(jQuery('.total-questions').text(), 10);
         if (isNaN(correctAnswers) || totalQuestions <= 0) return;
@@ -40,9 +47,9 @@ jQuery(document).on('learndash-quiz-finished', function () {
 
             jQuery.post(ajax_object.ajaxurl, {
                 action: 'enviar_correo_final_quiz',
-                user_id: quizData.userId,
                 quiz_id: quizData.quizId,
-                quiz_percentage: percentage
+                quiz_percentage: percentage,
+                nonce: finalQuizNonce
             }, function (response) {
                 if (response.success) {
                     console.log('📩 FINAL QUIZ EMAIL response:', response);

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -495,29 +495,31 @@ $is_checked = ($puntaje_privado === '1' || $puntaje_privado === 1) ? 'checked' :
         var isFirstQuiz = <?php echo $is_first_quiz ? 'true' : 'false'; ?>;
 
         jQuery(document).ready(function($) {
-    $(document).on('learndash-quiz-finished', function() {
-        var correctAnswers = parseInt($('.wpProQuiz_correct_answer').text(), 10);
-        var totalQuestions = parseInt($('.total-questions').text(), 10);
+            const firstQuizNonce = (typeof quizData !== 'undefined' && quizData.firstQuizNonce) ? quizData.firstQuizNonce : '';
 
-        if (!isNaN(correctAnswers) && totalQuestions > 0) {
-            var percentage = Math.round((correctAnswers / totalQuestions) * 100);
-            $('#quiz-percentage').text(percentage + '%');
-            $('#quiz-progress-bar').css('width', percentage + '%');
+            $(document).on('learndash-quiz-finished', function() {
+                var correctAnswers = parseInt($('.wpProQuiz_correct_answer').text(), 10);
+                var totalQuestions = parseInt($('.total-questions').text(), 10);
 
-            if (isFirstQuiz) {
-                $.post(ajaxurl, {
-                    action: 'enviar_correo_first_quiz',
-                    quiz_percentage: percentage,
-                    quiz_id: <?php echo (int)$quiz_id; ?>,
-                    user_id: <?php echo get_current_user_id(); ?>
-                }, function(response) {
-                    console.log('Correo enviado (First Quiz):', response);
-                });
-            } 
-            // IMPORTANTE: No hacer nada aquí si es Final Quiz.
-        }
-    });
-});
+                if (!isNaN(correctAnswers) && totalQuestions > 0) {
+                    var percentage = Math.round((correctAnswers / totalQuestions) * 100);
+                    $('#quiz-percentage').text(percentage + '%');
+                    $('#quiz-progress-bar').css('width', percentage + '%');
+
+                    if (isFirstQuiz) {
+                        $.post(ajaxurl, {
+                            action: 'enviar_correo_first_quiz',
+                            quiz_percentage: percentage,
+                            quiz_id: <?php echo (int)$quiz_id; ?>,
+                            nonce: firstQuizNonce
+                        }, function(response) {
+                            console.log('Correo enviado (First Quiz):', response);
+                        });
+                    }
+                    // IMPORTANTE: No hacer nada aquí si es Final Quiz.
+                }
+            });
+        });
 
         </script>
 


### PR DESCRIPTION
## Summary
- require valid nonces and logged-in users before dispatching quiz completion emails
- expose quiz email nonces to the front-end and include them in AJAX payloads
- update quiz scripts to rely on the current session user when triggering emails

## Testing
- php -l my-ld-course-override.php
- php -l templates/show_quiz_result_box.php

------
https://chatgpt.com/codex/tasks/task_e_68dee19173c48332bfc51fdce5c05e8b