### PR TITLE
Use debug logging for header warnings

### DIFF
--- a/parts/comprar-stats.php
+++ b/parts/comprar-stats.php
@@ -212,7 +212,7 @@ function mostrar_comprar_stats() {
     <?php
 }
 
-if (headers_sent($file, $line)) {
-    echo "Headers already sent in $file on line $line";
+if (defined('WP_DEBUG') && WP_DEBUG && headers_sent($file, $line)) {
+    error_log(sprintf('Headers already sent in %s on line %d', $file, $line));
 }
 ?>


### PR DESCRIPTION
## Summary
- replace the header troubleshooting echo with WP_DEBUG-guarded error_log logging to avoid exposing filesystem paths in the widget

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dee539220c8332aff8ab4f0f9970e2