### PR TITLE
Add Select2-powered LearnDash quiz metaboxes

### DIFF
--- a/assets/js/course-quiz-metabox.js
+++ b/assets/js/course-quiz-metabox.js
@@ -1,0 +1,64 @@
+(function ($) {
+    'use strict';
+
+    $(function () {
+        if (typeof $.fn.select2 === 'undefined') {
+            return;
+        }
+
+        var data = window.villegasCourseQuizData || {};
+        var labels = data.labels || {};
+
+        $('.villegas-quiz-select').each(function () {
+            var $select = $(this);
+            var placeholder = $select.data('placeholder') || labels.placeholder || '';
+            var selectedId = $select.data('selected-id');
+            var selectedText = $select.data('selected-text');
+
+            if (selectedId && selectedText) {
+                var existingOption = $select.find('option[value="' + selectedId + '"]');
+                if (!existingOption.length) {
+                    var option = new Option(selectedText, selectedId, true, true);
+                    $select.append(option);
+                }
+            }
+
+            $select.select2({
+                width: '100%',
+                ajax: {
+                    url: data.restUrl,
+                    dataType: 'json',
+                    delay: 250,
+                    cache: true,
+                    headers: {
+                        'X-WP-Nonce': data.nonce || ''
+                    },
+                    data: function (params) {
+                        return {
+                            search: params.term || ''
+                        };
+                    },
+                    processResults: function (response) {
+                        return {
+                            results: response && response.results ? response.results : []
+                        };
+                    }
+                },
+                placeholder: placeholder,
+                allowClear: true,
+                minimumInputLength: 1,
+                language: {
+                    inputTooShort: function () {
+                        return labels.inputTooShort || '';
+                    },
+                    noResults: function () {
+                        return labels.noResults || '';
+                    },
+                    searching: function () {
+                        return labels.searching || '';
+                    }
+                }
+            });
+        });
+    });
+})(jQuery);

--- a/metabox-course-first-quiz.php
+++ b/metabox-course-first-quiz.php
@@ -1,87 +1,257 @@
 <?php
-// Añadir el metabox para seleccionar el Quiz Inicial
-function add_first_quiz_metabox() {
+/**
+ * LearnDash Course Quiz metaboxes with AJAX Select2 search.
+ */
+
+add_action( 'add_meta_boxes', 'villegas_register_course_quiz_metaboxes' );
+/**
+ * Register First and Final quiz metaboxes on LearnDash courses.
+ */
+function villegas_register_course_quiz_metaboxes() {
     add_meta_box(
-        'first_quiz_metabox',           // ID único
-        'Quiz Inicial',                 // Título del metabox
-        'render_first_quiz_metabox',    // Función de callback que renderiza el contenido
-        'sfwd-courses',                 // Pantalla o post type
-        'side',                         // Contexto (donde aparecerá: 'normal', 'side', 'advanced')
-        'high'                          // Prioridad
+        'villegas_first_quiz_metabox',
+        __( 'First Quiz', 'villegas-courses' ),
+        'villegas_render_course_quiz_metabox',
+        'sfwd-courses',
+        'side',
+        'default',
+        array(
+            'meta_key'   => '_first_quiz_id',
+            'field_id'   => 'villegas-first-quiz',
+            'field_name' => 'villegas_first_quiz',
+            'label'      => __( 'Select the First Quiz', 'villegas-courses' ),
+        )
+    );
+
+    add_meta_box(
+        'villegas_final_quiz_metabox',
+        __( 'Final Quiz', 'villegas-courses' ),
+        'villegas_render_course_quiz_metabox',
+        'sfwd-courses',
+        'side',
+        'default',
+        array(
+            'meta_key'   => '_final_quiz_id',
+            'field_id'   => 'villegas-final-quiz',
+            'field_name' => 'villegas_final_quiz',
+            'label'      => __( 'Select the Final Quiz', 'villegas-courses' ),
+        )
     );
 }
-add_action('add_meta_boxes', 'add_first_quiz_metabox');
 
-// Renderizar el metabox con un dropdown para seleccionar el quiz
-function render_first_quiz_metabox($post) {
-    // Obtener el ID del quiz seleccionado previamente (si existe)
-    $selected_quiz_id = get_post_meta($post->ID, '_first_quiz_id', true);
+/**
+ * Render the Select2 enabled metabox field.
+ *
+ * @param WP_Post $post Current post object.
+ * @param array   $box  Metabox configuration.
+ */
+function villegas_render_course_quiz_metabox( $post, $box ) {
+    static $nonce_printed = false;
 
-    // Query para obtener todos los quizzes publicados que no estén asociados a ningún curso
-    $args = array(
-        'post_type' => 'sfwd-quiz',           // Tipo de post: Quiz de LearnDash
-        'posts_per_page' => -1,               // Obtener todos los quizzes
-        'post_status' => 'publish',           // Solo quizzes publicados
-        'meta_query' => array(
-            array(
-                'key' => 'course_id',        // Filtrar los quizzes que no tienen curso asociado
-                'compare' => 'NOT EXISTS'
+    $meta_key   = isset( $box['args']['meta_key'] ) ? $box['args']['meta_key'] : '';
+    $field_id   = isset( $box['args']['field_id'] ) ? $box['args']['field_id'] : '';
+    $field_name = isset( $box['args']['field_name'] ) ? $box['args']['field_name'] : '';
+    $label      = isset( $box['args']['label'] ) ? $box['args']['label'] : '';
+
+    $selected_quiz_id = $meta_key ? get_post_meta( $post->ID, $meta_key, true ) : '';
+    $selected_quiz    = $selected_quiz_id ? get_post( (int) $selected_quiz_id ) : null;
+
+    if ( ! $nonce_printed ) {
+        wp_nonce_field( 'villegas_course_quiz_metabox', 'villegas_course_quiz_nonce' );
+        $nonce_printed = true;
+    }
+    ?>
+    <p>
+        <label for="<?php echo esc_attr( $field_id ); ?>"><?php echo esc_html( $label ); ?></label>
+    </p>
+    <select
+        id="<?php echo esc_attr( $field_id ); ?>"
+        name="<?php echo esc_attr( $field_name ); ?>"
+        class="villegas-quiz-select"
+        data-placeholder="<?php echo esc_attr__( 'Search for a quiz…', 'villegas-courses' ); ?>"
+        data-selected-id="<?php echo esc_attr( $selected_quiz_id ); ?>"
+        data-selected-text="<?php echo $selected_quiz ? esc_attr( $selected_quiz->post_title ) : ''; ?>"
+        style="width:100%;"
+    >
+        <option value=""></option>
+        <?php if ( $selected_quiz ) : ?>
+            <option value="<?php echo esc_attr( $selected_quiz_id ); ?>" selected>
+                <?php echo esc_html( $selected_quiz->post_title ); ?>
+            </option>
+        <?php endif; ?>
+    </select>
+    <?php
+}
+
+add_action( 'save_post', 'villegas_save_course_quiz_metabox', 10, 2 );
+/**
+ * Persist the selected quiz IDs for the current course.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ */
+function villegas_save_course_quiz_metabox( $post_id, $post ) {
+    if ( 'sfwd-courses' !== $post->post_type ) {
+        return;
+    }
+
+    if ( ! isset( $_POST['villegas_course_quiz_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['villegas_course_quiz_nonce'] ) ), 'villegas_course_quiz_metabox' ) ) {
+        return;
+    }
+
+    if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+        return;
+    }
+
+    if ( ! current_user_can( 'edit_posts' ) || ! current_user_can( 'edit_post', $post_id ) ) {
+        return;
+    }
+
+    $fields = array(
+        'villegas_first_quiz' => '_first_quiz_id',
+        'villegas_final_quiz' => '_final_quiz_id',
+    );
+
+    foreach ( $fields as $field_name => $meta_key ) {
+        if ( isset( $_POST[ $field_name ] ) ) {
+            $value = absint( wp_unslash( $_POST[ $field_name ] ) );
+            if ( $value ) {
+                update_post_meta( $post_id, $meta_key, $value );
+            } else {
+                delete_post_meta( $post_id, $meta_key );
+            }
+        } else {
+            delete_post_meta( $post_id, $meta_key );
+        }
+    }
+}
+
+add_action( 'admin_enqueue_scripts', 'villegas_course_quiz_metabox_assets' );
+/**
+ * Enqueue Select2 assets and localised data for the metaboxes.
+ *
+ * @param string $hook Current admin page hook suffix.
+ */
+function villegas_course_quiz_metabox_assets( $hook ) {
+    if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+        return;
+    }
+
+    $screen = get_current_screen();
+    if ( ! $screen || 'sfwd-courses' !== $screen->post_type ) {
+        return;
+    }
+
+    wp_enqueue_style(
+        'villegas-select2',
+        'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css',
+        array(),
+        '4.1.0-rc.0'
+    );
+
+    wp_enqueue_script(
+        'villegas-select2',
+        'https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js',
+        array( 'jquery' ),
+        '4.1.0-rc.0',
+        true
+    );
+
+    wp_enqueue_script(
+        'villegas-course-quiz-metabox',
+        plugin_dir_url( __FILE__ ) . 'assets/js/course-quiz-metabox.js',
+        array( 'jquery', 'villegas-select2' ),
+        '1.0.0',
+        true
+    );
+
+    wp_localize_script(
+        'villegas-course-quiz-metabox',
+        'villegasCourseQuizData',
+        array(
+            'restUrl' => esc_url_raw( rest_url( 'villegas-course/v1/quizzes' ) ),
+            'nonce'   => wp_create_nonce( 'wp_rest' ),
+            'labels'  => array(
+                'placeholder'   => __( 'Search for a quiz…', 'villegas-courses' ),
+                'noResults'     => __( 'No quizzes found.', 'villegas-courses' ),
+                'searching'     => __( 'Searching…', 'villegas-courses' ),
+                'inputTooShort' => __( 'Please enter 1 or more characters', 'villegas-courses' ),
             ),
-        ),
+        )
     );
-    $quizzes = get_posts($args);
-
-    // Seguridad: Generar un nonce para la validación del formulario
-    wp_nonce_field('save_first_quiz_metabox', 'first_quiz_nonce');
-
-    // Crear el dropdown
-    echo '<label for="first_quiz">Selecciona el Quiz Inicial:</label>';
-    echo '<select name="first_quiz" id="first_quiz">';
-    echo '<option value="">-- Selecciona un quiz --</option>';
-
-    foreach ($quizzes as $quiz) {
-        echo '<option value="' . esc_attr($quiz->ID) . '" ' . selected($selected_quiz_id, $quiz->ID, false) . '>' . esc_html($quiz->post_title) . '</option>';
-    }
-
-    echo '</select>';
 }
 
-// Guardar el Quiz Inicial seleccionado
-function save_first_quiz_metabox($post_id) {
-    // Verificar el nonce para asegurar que el formulario fue enviado desde nuestra pantalla
-    if (!isset($_POST['first_quiz_nonce']) || !wp_verify_nonce($_POST['first_quiz_nonce'], 'save_first_quiz_metabox')) {
-        return;
-    }
-
-    // Verificar que no sea un autosave
-    if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
-        return;
-    }
-
-    // Verificar que el usuario tenga permiso para editar el post
-    if (!current_user_can('edit_post', $post_id)) {
-        return;
-    }
-
-    // Verificar si el campo "first_quiz" está presente en la solicitud
-    if (isset($_POST['first_quiz'])) {
-        $first_quiz_id = sanitize_text_field($_POST['first_quiz']);
-        // Guardar el ID del quiz como meta data
-        update_post_meta($post_id, '_first_quiz_id', $first_quiz_id);
-    } else {
-        // Si no se selecciona nada, eliminar el meta data
-        delete_post_meta($post_id, '_first_quiz_id');
-    }
+add_action( 'rest_api_init', 'villegas_register_quiz_search_route' );
+/**
+ * Register the REST API route for quiz searching.
+ */
+function villegas_register_quiz_search_route() {
+    register_rest_route(
+        'villegas-course/v1',
+        '/quizzes',
+        array(
+            'methods'             => WP_REST_Server::READABLE,
+            'callback'            => 'villegas_rest_search_quizzes',
+            'permission_callback' => 'villegas_rest_quiz_permission_check',
+            'args'                => array(
+                'search' => array(
+                    'description' => __( 'Quiz search term.', 'villegas-courses' ),
+                    'type'        => 'string',
+                    'required'    => false,
+                    'sanitize_callback' => 'sanitize_text_field',
+                ),
+            ),
+        )
+    );
 }
-add_action('save_post', 'save_first_quiz_metabox');
 
-
-// Cargar solo los scripts necesarios en la pantalla de edición del curso
-function enqueue_metabox_admin_scripts($hook_suffix) {
-    global $post_type;
-    if ('sfwd-courses' === $post_type && 'post.php' === $hook_suffix) {
-        // Cargar cualquier script o estilo que necesites, si es necesario
-        wp_enqueue_script('my-metabox-script', plugin_dir_url(__FILE__) . 'assets/js/custom-metabox.js', array('jquery'), null, true);
-    }
+/**
+ * Permission callback for the quiz search route.
+ *
+ * @return bool
+ */
+function villegas_rest_quiz_permission_check() {
+    return current_user_can( 'edit_posts' );
 }
-add_action('admin_enqueue_scripts', 'enqueue_metabox_admin_scripts');
+
+/**
+ * REST callback that searches for quizzes by title and returns Select2 formatted data.
+ *
+ * @param WP_REST_Request $request Request instance.
+ *
+ * @return WP_REST_Response
+ */
+function villegas_rest_search_quizzes( WP_REST_Request $request ) {
+    $search = $request->get_param( 'search' );
+
+    $query_args = array(
+        'post_type'      => 'sfwd-quiz',
+        'post_status'    => 'publish',
+        'posts_per_page' => 20,
+        'orderby'        => 'title',
+        'order'          => 'ASC',
+    );
+
+    if ( ! empty( $search ) ) {
+        $query_args['s'] = $search;
+    }
+
+    $query = new WP_Query( $query_args );
+
+    $results = array();
+
+    if ( $query->have_posts() ) {
+        foreach ( $query->posts as $quiz ) {
+            $results[] = array(
+                'id'   => $quiz->ID,
+                'text' => html_entity_decode( wp_strip_all_tags( $quiz->post_title ), ENT_QUOTES, get_bloginfo( 'charset' ) ),
+            );
+        }
+    }
+
+    return rest_ensure_response(
+        array(
+            'results' => $results,
+        )
+    );
+}


### PR DESCRIPTION
## Summary
- replace the course quiz metabox implementation with Select2-powered First and Final quiz selectors
- add an authenticated REST endpoint to search published quizzes for the Select2 autocomplete
- enqueue admin assets and persist the selected quiz IDs in post meta, clearing the meta when empty

## Testing
- php -l metabox-course-first-quiz.php

------
https://chatgpt.com/codex/tasks/task_e_68dfbbef76108332a9088dc225111f82