### PR TITLE
Refactor quiz analytics to use metadata helpers

### DIFF
--- a/classes/class-course-quiz-helper.php
+++ b/classes/class-course-quiz-helper.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Helper utilities to resolve course/quiz relationships using metadata.
+ */
+class CourseQuizMetaHelper {
+    /**
+     * Retrieve the First Quiz ID for a course.
+     *
+     * @param int $course_id Course post ID.
+     * @return int Quiz ID or 0 when not configured.
+     */
+    public static function getFirstQuizId( $course_id ) {
+        $course_id = intval( $course_id );
+        if ( ! $course_id ) {
+            return 0;
+        }
+
+        $quiz_id = get_post_meta( $course_id, '_first_quiz_id', true );
+        return $quiz_id ? intval( $quiz_id ) : 0;
+    }
+
+    /**
+     * Retrieve the Final Quiz ID for a course.
+     *
+     * @param int $course_id Course post ID.
+     * @return int Quiz ID or 0 when not configured.
+     */
+    public static function getFinalQuizId( $course_id ) {
+        $course_id = intval( $course_id );
+        if ( ! $course_id ) {
+            return 0;
+        }
+
+        $quiz_id = get_post_meta( $course_id, '_final_quiz_id', true );
+        return $quiz_id ? intval( $quiz_id ) : 0;
+    }
+
+    /**
+     * Resolve the course ID that owns a quiz.
+     *
+     * @param int $quiz_id Quiz post ID.
+     * @return int Course ID or 0 if none could be resolved.
+     */
+    public static function getCourseFromQuiz( $quiz_id ) {
+        global $wpdb;
+
+        $quiz_id = intval( $quiz_id );
+        if ( ! $quiz_id ) {
+            return 0;
+        }
+
+        // Look for a course that references the quiz via metadata.
+        $course_id = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT post_id
+                   FROM {$wpdb->postmeta}
+                  WHERE meta_key IN ('_first_quiz_id', '_final_quiz_id')
+                    AND meta_value = %d
+               ORDER BY post_id ASC
+                  LIMIT 1",
+                $quiz_id
+            )
+        );
+
+        if ( $course_id ) {
+            return intval( $course_id );
+        }
+
+        // Fallback to LearnDash helper if available.
+        if ( function_exists( 'learndash_get_course_id' ) ) {
+            $fallback = intval( learndash_get_course_id( $quiz_id ) );
+            if ( $fallback ) {
+                return $fallback;
+            }
+        }
+
+        // Final fallback: scan ld_course_steps for backwards compatibility.
+        $course_id = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT post_id
+                   FROM {$wpdb->postmeta}
+                  WHERE meta_key = 'ld_course_steps'
+                    AND meta_value LIKE %s
+                  LIMIT 1",
+                '%i:' . $quiz_id . ';%'
+            )
+        );
+
+        return $course_id ? intval( $course_id ) : 0;
+    }
+}

--- a/my-ld-course-override.php
+++ b/my-ld-course-override.php
@@ -6,6 +6,10 @@
  * Author: Nicolás Pavez
  */
 
+if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'classes/class-course-quiz-helper.php';
+}
+
 // Reemplazar la plantilla del curso de LearnDash
 function my_custom_ld_course_template( $template ) {
     if ( is_singular( 'sfwd-courses' ) ) {
@@ -166,8 +170,8 @@ if ( is_singular( 'sfwd-quiz' ) ) {
     );
 
     $quiz_id      = get_the_ID();
-    $course_id    = learndash_get_course_id( $quiz_id );
-    $course_title = get_the_title( $course_id );
+    $course_id    = CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+    $course_title = $course_id ? get_the_title( $course_id ) : '';
 
     // -----------------------------------------------------------
     // DEBUG: Verificamos qué devuelve QuizAnalytics para este quiz
@@ -354,13 +358,8 @@ function enviar_correo_first_quiz_handler() {
     $user_name  = $user->display_name;
     $quiz_title = get_the_title($quiz_id);
 
-    // Obtener Course ID desde el First Quiz
-    $course_id = $wpdb->get_var($wpdb->prepare(
-        "SELECT post_id FROM {$wpdb->prefix}postmeta 
-         WHERE meta_key = '_first_quiz_id' AND meta_value = %d 
-         LIMIT 1",
-        $quiz_id
-    ));
+    // Obtener Course ID desde la metadata configurada
+    $course_id = CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
 
     // Verificar acceso al curso
     $tiene_acceso = $course_id ? sfwd_lms_has_access($course_id, $user_id) : false;
@@ -542,8 +541,8 @@ function handle_enviar_correo_final_quiz() {
 	$first_bar_style = $first_pct > 0 ? "width: {$first_pct}%; background-color: #ff9800;" : "width: 0%;" ;
 
 	// ---------- Preparar plantilla ----------
-	$course_id    = learndash_get_course_id( $quiz_id );
-	$course_title = get_the_title( $course_id );
+        $course_id    = CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+        $course_title = $course_id ? get_the_title( $course_id ) : '';
 	$subject      = '¡Has completado el Final Quiz!';
 	$headers      = [ 'Content-Type: text/html; charset=UTF-8' ];
     $quiz_title   = get_the_title( $quiz_id );

--- a/partials/ajax-results-box.php
+++ b/partials/ajax-results-box.php
@@ -3,6 +3,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+}
+
 $course_id = intval( $_POST['course_id'] ?? 0 );
 $user_id   = get_current_user_id();
 
@@ -83,9 +87,8 @@ function villegas_build_quiz_data( $wpdb, $attempt ) {
 // Datos del curso / quizzes
 // -----------------------------------------------------------------------------
 $course_title   = get_the_title( $course_id );
-$first_quiz_id  = intval( get_post_meta( $course_id, '_first_quiz_id', true ) );
-$quiz_steps     = learndash_course_get_steps_by_type( $course_id, 'sfwd-quiz' );
-$final_quiz_id  = ! empty( $quiz_steps ) ? end( $quiz_steps ) : 0;
+$first_quiz_id  = CourseQuizMetaHelper::getFirstQuizId( $course_id );
+$final_quiz_id  = CourseQuizMetaHelper::getFinalQuizId( $course_id );
 
 $first_data = villegas_build_quiz_data(
     $wpdb,

--- a/parts/comprar-stats.php
+++ b/parts/comprar-stats.php
@@ -1,4 +1,8 @@
 <?php
+
+if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+}
 ob_start();
 
 // Function to get latest quiz percentage
@@ -88,9 +92,9 @@ function mostrar_comprar_stats() {
     }
 
     // First quiz ID and URL
-    $first_quiz_id = get_post_meta($course_id, '_first_quiz_id', true);
-    $first_quiz_url = !empty($first_quiz_id) && ($quiz_post = get_post($first_quiz_id)) 
-        ? home_url('/evaluaciones/' . $quiz_post->post_name . '/') 
+    $first_quiz_id = CourseQuizMetaHelper::getFirstQuizId( $course_id );
+    $first_quiz_url = !empty($first_quiz_id) && ($quiz_post = get_post($first_quiz_id))
+        ? home_url('/evaluaciones/' . $quiz_post->post_name . '/')
         : '#';
 
     // Course progress
@@ -167,7 +171,7 @@ function mostrar_comprar_stats() {
                 <div id="final-test-button" class="tooltip" style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                     <?php
                     global $wpdb;
-                    $final_quiz_id = end(learndash_course_get_steps_by_type($course_id, 'sfwd-quiz')) ?: 0;
+                    $final_quiz_id = CourseQuizMetaHelper::getFinalQuizId( $course_id );
                     $final_quiz_url = $final_quiz_id ? get_permalink($final_quiz_id) : '';
 
                     $latest_attempt_final = $wpdb->get_row($wpdb->prepare(

--- a/shortcodes/quiz-class-shortcodes.php
+++ b/shortcodes/quiz-class-shortcodes.php
@@ -1,4 +1,8 @@
 <?php
+
+if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+}
 // Shortcode to display course name, First Quiz status, number of attempts, and attempt percentages
 function shortcode_display_course_and_quiz_status($atts) {
     $atts = shortcode_atts(
@@ -16,7 +20,7 @@ function shortcode_display_course_and_quiz_status($atts) {
     }
 
     // Retrieve the First Quiz ID
-    $first_quiz_id   = get_post_meta($course_id, '_first_quiz_id', true);
+    $first_quiz_id   = CourseQuizMetaHelper::getFirstQuizId( $course_id );
     $has_first_quiz  = $first_quiz_id ? 'Yes' : 'No';
 
     $user_id          = get_current_user_id();
@@ -108,28 +112,8 @@ function shortcode_display_course_and_final_quiz_status($atts) {
         return "Course not found.";
     }
 
-    // Retrieve course steps meta
-    $course_steps = get_post_meta($course_id, 'ld_course_steps', true);
-    $final_quiz_exists = 'No';
-    $final_quiz_id     = null;
-
-    // Convert steps to array (in case it's serialized)
-    if (!empty($course_steps) && !is_array($course_steps)) {
-        $course_steps = @unserialize($course_steps);
-    }
-
-    // Find the "final" quiz in the course steps
-    if (!empty($course_steps['steps']) && is_array($course_steps['steps'])) {
-        foreach ($course_steps['steps'] as $step) {
-            if (!empty($step['sfwd-quiz']) && is_array($step['sfwd-quiz'])) {
-                foreach ($step['sfwd-quiz'] as $quiz_id => $quiz_data) {
-                    $final_quiz_exists = 'Yes';
-                    $final_quiz_id     = $quiz_id;
-                    break 2;  // Exit both loops when found
-                }
-            }
-        }
-    }
+    $final_quiz_id     = CourseQuizMetaHelper::getFinalQuizId( $course_id );
+    $final_quiz_exists = $final_quiz_id ? 'Yes' : 'No';
 
     $user_id = get_current_user_id();
     global $wpdb;

--- a/shortcodes/shortcode-cursos-finalizados.php
+++ b/shortcodes/shortcode-cursos-finalizados.php
@@ -1,4 +1,8 @@
 <?php
+
+if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+}
 /**
  * Shortcode: [cursos_finalizados]
  * Muestra los cursos en los que el usuario está inscrito, con estado de quizzes y estadísticas.
@@ -49,14 +53,14 @@ function villegas_shortcode_cursos_finalizados() {
         echo '<hr>';
 
         // Obtener IDs de quizzes
-        $first_quiz_id = get_post_meta($course_id, '_first_quiz_id', true);
-        $quiz_steps = learndash_course_get_steps_by_type($course_id, 'sfwd-quiz');
-        $final_quiz_id = !empty($quiz_steps) ? end($quiz_steps) : 0;
+        $first_quiz_id = CourseQuizMetaHelper::getFirstQuizId( $course_id );
+        $final_quiz_id = CourseQuizMetaHelper::getFinalQuizId( $course_id );
 
         // === PRUEBA INICIAL ===
         echo '<div class="quiz-row-inicial">';
         echo '<div><div class="quiz-label">Prueba Inicial</div>';
-        if (villegas_is_quiz_completed($first_quiz_id, $user_id)) {
+        $first_completed = $first_quiz_id ? villegas_is_quiz_completed($first_quiz_id, $user_id) : false;
+        if ($first_completed) {
             $date = get_quiz_completion_date($first_quiz_id, $user_id);
             echo '<div class="quiz-date">' . esc_html($date) . '</div>';
         } else {
@@ -64,10 +68,11 @@ function villegas_shortcode_cursos_finalizados() {
         }
         echo '</div>';
 
-        if (villegas_is_quiz_completed($first_quiz_id, $user_id)) {
+        if ($first_completed) {
             echo villegas_render_quiz_result($first_quiz_id, $user_id);
         } else {
-            echo '<a class="quiz-status-link" style="font-size:11px; letter-spacing: 4px;" href="' . esc_url(get_permalink($first_quiz_id)) . '">NO RENDIDA</a>';
+            $first_quiz_link = $first_quiz_id ? get_permalink($first_quiz_id) : get_permalink($course_id);
+            echo '<a class="quiz-status-link" style="font-size:11px; letter-spacing: 4px;" href="' . esc_url($first_quiz_link) . '">NO RENDIDA</a>';
             echo '<span class="quiz-percentage">–</span>';
         }
         echo '</div>';


### PR DESCRIPTION
## Summary
- add a dedicated CourseQuizMetaHelper with metadata-aware helpers for resolving first/final quiz IDs and their parent courses
- migrate QuizAnalytics and quiz-driven features to rely on the new helpers and meta keys instead of scanning ld_course_steps
- update front-end shortcodes, templates, and partials to degrade gracefully when quiz metadata is missing while using the helper methods

## Testing
- php -l classes/class-course-quiz-helper.php
- php -l classes/class-quiz-analytics.php
- php -l functions.php
- php -l shortcodes/quiz-class-shortcodes.php
- php -l shortcodes/shortcode-cursos-finalizados.php
- php -l templates/archive-sfwd-courses.php
- php -l parts/comprar-stats.php
- php -l partials/ajax-results-box.php
- php -l my-ld-course-override.php

------
https://chatgpt.com/codex/tasks/task_e_68dfbdc673cc8332b9f3f07bb4ae2f95