### PR TITLE
Refactor quiz result stats to use metadata helpers

### DIFF
--- a/classes/class-politeia-course.php
+++ b/classes/class-politeia-course.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Helper utilities that resolve course and commerce metadata for quizzes.
+ */
+class PoliteiaCourse {
+    /**
+     * Ensure legacy helper is available for backwards compatibility.
+     */
+    protected static function ensure_helper() {
+        if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+            require_once plugin_dir_path( __FILE__ ) . 'class-course-quiz-helper.php';
+        }
+    }
+
+    /**
+     * Retrieve the course ID that owns a quiz using metadata.
+     *
+     * @param int $quiz_id Quiz post ID.
+     * @return int Course ID or 0 when it cannot be resolved.
+     */
+    public static function getCourseFromQuiz( $quiz_id ) {
+        self::ensure_helper();
+
+        return CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+    }
+
+    /**
+     * Retrieve the first quiz configured for a course.
+     *
+     * @param int $course_id Course post ID.
+     * @return int Quiz ID or 0 when none is configured.
+     */
+    public static function getFirstQuizId( $course_id ) {
+        self::ensure_helper();
+
+        return CourseQuizMetaHelper::getFirstQuizId( $course_id );
+    }
+
+    /**
+     * Retrieve the final quiz configured for a course.
+     *
+     * @param int $course_id Course post ID.
+     * @return int Quiz ID or 0 when none is configured.
+     */
+    public static function getFinalQuizId( $course_id ) {
+        self::ensure_helper();
+
+        return CourseQuizMetaHelper::getFinalQuizId( $course_id );
+    }
+
+    /**
+     * Resolve the WooCommerce product related to a course.
+     *
+     * @param int $course_id Course post ID.
+     * @return int Product ID or 0 when none is linked.
+     */
+    public static function getRelatedProductId( $course_id ) {
+        $course_id = intval( $course_id );
+
+        if ( ! $course_id ) {
+            return 0;
+        }
+
+        $product_id = get_post_meta( $course_id, '_linked_woocommerce_product', true );
+
+        if ( $product_id ) {
+            return intval( $product_id );
+        }
+
+        $products = get_posts(
+            [
+                'post_type'      => 'product',
+                'post_status'    => 'publish',
+                'meta_query'     => [
+                    [
+                        'key'     => '_related_course',
+                        'value'   => $course_id,
+                        'compare' => 'LIKE',
+                    ],
+                ],
+                'posts_per_page' => 1,
+                'fields'         => 'ids',
+            ]
+        );
+
+        return $products ? intval( $products[0] ) : 0;
+    }
+
+    /**
+     * Determine whether the user has access to a course.
+     *
+     * @param int $course_id Course post ID.
+     * @param int $user_id   User ID.
+     * @return bool
+     */
+    public static function userHasAccess( $course_id, $user_id ) {
+        $course_id = intval( $course_id );
+        $user_id   = intval( $user_id );
+
+        if ( ! $course_id || ! $user_id ) {
+            return false;
+        }
+
+        return (bool) sfwd_lms_has_access( $course_id, $user_id );
+    }
+}

--- a/classes/class-politeia-quiz-stats.php
+++ b/classes/class-politeia-quiz-stats.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Aggregates quiz analytics data for template rendering.
+ */
+class Politeia_Quiz_Stats {
+    /**
+     * Quiz ID currently being rendered.
+     *
+     * @var int
+     */
+    protected $quiz_id;
+
+    /**
+     * User ID for which the stats are being collected.
+     *
+     * @var int
+     */
+    protected $user_id;
+
+    /**
+     * Underlying analytics helper.
+     *
+     * @var QuizAnalytics
+     */
+    protected $analytics;
+
+    public function __construct( $quiz_id, $user_id = null ) {
+        $this->quiz_id = intval( $quiz_id );
+        $this->user_id = $user_id ? intval( $user_id ) : get_current_user_id();
+
+        if ( ! class_exists( 'QuizAnalytics' ) ) {
+            require_once plugin_dir_path( __FILE__ ) . 'class-quiz-analytics.php';
+        }
+
+        $this->analytics = new QuizAnalytics( $this->quiz_id, $this->user_id );
+    }
+
+    /**
+     * Get the course ID owning the quiz.
+     */
+    public function get_course_id() {
+        return $this->analytics->getCourse();
+    }
+
+    /**
+     * Whether the current quiz is configured as the first quiz.
+     */
+    public function is_first_quiz() {
+        return $this->analytics->isFirstQuiz();
+    }
+
+    /**
+     * Whether the current quiz is configured as the final quiz.
+     */
+    public function is_final_quiz() {
+        return $this->analytics->isFinalQuiz();
+    }
+
+    /**
+     * Get metadata for the configured first quiz.
+     */
+    public function get_first_quiz_id() {
+        return $this->analytics->getFirstQuiz();
+    }
+
+    /**
+     * Get metadata for the configured final quiz.
+     */
+    public function get_final_quiz_id() {
+        return $this->analytics->getFinalQuiz();
+    }
+
+    /**
+     * Return attempt information for the quiz currently in context.
+     */
+    public function get_current_quiz_summary() {
+        return $this->get_quiz_summary( $this->quiz_id );
+    }
+
+    /**
+     * Return attempt information for the first quiz.
+     */
+    public function get_first_quiz_summary() {
+        $quiz_id = $this->get_first_quiz_id();
+
+        return $quiz_id ? $this->get_quiz_summary( $quiz_id ) : $this->empty_summary( $quiz_id );
+    }
+
+    /**
+     * Return attempt information for the final quiz.
+     */
+    public function get_final_quiz_summary() {
+        $quiz_id = $this->get_final_quiz_id();
+
+        return $quiz_id ? $this->get_quiz_summary( $quiz_id ) : $this->empty_summary( $quiz_id );
+    }
+
+    /**
+     * Access raw analytics object when needed.
+     */
+    public function get_analytics() {
+        return $this->analytics;
+    }
+
+    /**
+     * Build a quiz attempt summary.
+     */
+    public function get_quiz_summary( $quiz_id ) {
+        $quiz_id     = intval( $quiz_id );
+        $performance = $this->analytics->getQuizPerformance( $quiz_id );
+
+        $percentage = is_numeric( $performance['percentage'] ?? null )
+            ? floatval( $performance['percentage'] )
+            : null;
+
+        $timestamp = isset( $performance['timestamp'] ) ? intval( $performance['timestamp'] ) : 0;
+
+        return [
+            'quiz_id'            => $quiz_id,
+            'score'              => intval( $performance['score'] ?? 0 ),
+            'percentage'         => $percentage,
+            'percentage_rounded' => is_null( $percentage ) ? null : round( $percentage ),
+            'timestamp'          => $timestamp,
+            'date'               => $performance['date'] ?? null,
+            'has_attempt'        => $timestamp > 0,
+            'formatted_date'     => $timestamp > 0 ? date_i18n( 'j \d\e F \d\e Y', $timestamp ) : null,
+        ];
+    }
+
+    protected function empty_summary( $quiz_id ) {
+        return [
+            'quiz_id'            => $quiz_id ? intval( $quiz_id ) : 0,
+            'score'              => 0,
+            'percentage'         => null,
+            'percentage_rounded' => null,
+            'timestamp'          => 0,
+            'date'               => null,
+            'has_attempt'        => false,
+            'formatted_date'     => null,
+        ];
+    }
+}

--- a/classes/class-quiz-analytics.php
+++ b/classes/class-quiz-analytics.php
@@ -78,7 +78,6 @@ class QuizAnalytics {
     private function getUserQuizPerformance( $quiz_id ) {
         global $wpdb;
 
-        // Buscar el intento más reciente (activity_id) para este usuario y quiz
         $activity_id = $wpdb->get_var(
             $wpdb->prepare(
                 "
@@ -100,11 +99,11 @@ class QuizAnalytics {
                 'score'      => 0,
                 'percentage' => 'N/A',
                 'attempts'   => 0,
-                'date'       => 'No Attempts'
+                'date'       => 'No Attempts',
+                'timestamp'  => 0,
             ];
         }
 
-        // Obtener puntuación (score)
         $score = $wpdb->get_var(
             $wpdb->prepare(
                 "
@@ -119,7 +118,6 @@ class QuizAnalytics {
         );
         $score = $score !== null ? intval( $score ) : 0;
 
-        // Obtener porcentaje (percentage)
         $percentage = $wpdb->get_var(
             $wpdb->prepare(
                 "
@@ -134,7 +132,6 @@ class QuizAnalytics {
         );
         $percentage = $percentage !== null ? floatval( $percentage ) : 'N/A';
 
-        // Obtener timestamp del último intento
         $latest_attempt_ts = $wpdb->get_var(
             $wpdb->prepare(
                 "
@@ -146,6 +143,7 @@ class QuizAnalytics {
                 $activity_id
             )
         );
+
         $attempt_date = ( $latest_attempt_ts && intval( $latest_attempt_ts ) > 0 )
             ? date_i18n( 'j \d\e F \d\e Y', intval( $latest_attempt_ts ) )
             : 'No Attempts';
@@ -154,8 +152,28 @@ class QuizAnalytics {
             'score'      => $score,
             'percentage' => $percentage,
             'attempts'   => 1,
-            'date'       => $attempt_date
+            'date'       => $attempt_date,
+            'timestamp'  => intval( $latest_attempt_ts ),
         ];
+    }
+
+    /**
+     * Retrieve performance information for any quiz ID.
+     */
+    public function getQuizPerformance( $quiz_id = null ) {
+        $quiz_id = $quiz_id ? intval( $quiz_id ) : $this->quiz_id;
+
+        if ( ! $quiz_id ) {
+            return [
+                'score'      => 0,
+                'percentage' => 'N/A',
+                'attempts'   => 0,
+                'date'       => 'No Attempts',
+                'timestamp'  => 0,
+            ];
+        }
+
+        return $this->getUserQuizPerformance( $quiz_id );
     }
 
     public function getFirstQuizTimestamp() {
@@ -209,7 +227,8 @@ class QuizAnalytics {
                 'score'      => 0,
                 'percentage' => 'N/A',
                 'attempts'   => 0,
-                'date'       => 'No Attempts'
+                'date'       => 'No Attempts',
+                'timestamp'  => 0,
             ];
         }
         return $this->getUserQuizPerformance( $this->first_quiz_id );
@@ -225,7 +244,8 @@ class QuizAnalytics {
                 'score'      => 0,
                 'percentage' => 'N/A',
                 'attempts'   => 0,
-                'date'       => 'No Attempts'
+                'date'       => 'No Attempts',
+                'timestamp'  => 0,
             ];
         }
         return $this->getUserQuizPerformance( $this->final_quiz_id );

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -1,42 +1,70 @@
 <?php
-
-function get_latest_quiz_score() {
-    global $wpdb;
-
-    $quiz_id = intval($_GET['quiz_id']);
-    $user_id = get_current_user_id();
-
-    // Esperar a que se registre el intento más reciente
-    for ($i = 0; $i < 5; $i++) {
-        $latest_attempt = $wpdb->get_row($wpdb->prepare(
-            "SELECT activity_id, activity_completed FROM {$wpdb->prefix}learndash_user_activity 
-            WHERE user_id = %d 
-            AND post_id = %d 
-            AND activity_type = 'quiz' 
-            ORDER BY activity_completed DESC 
-            LIMIT 1",
-            $user_id,
-            $quiz_id
-        ));
-
-        if ($latest_attempt && $latest_attempt->activity_completed > 0) {
-            break;
-        }
-        sleep(2); // Esperar 2 segundos antes de reintentar
-    }
-
-    if ($latest_attempt) {
-        $quiz_score = $wpdb->get_var($wpdb->prepare(
-            "SELECT activity_meta_value FROM {$wpdb->prefix}learndash_user_activity_meta 
-            WHERE activity_id = %d 
-            AND activity_meta_key = 'percentage'",
-            $latest_attempt->activity_id
-        ));
-
-        wp_send_json_success(['score' => floatval($quiz_score)]);
-    } else {
-        wp_send_json_error(['message' => 'No se encontró un intento reciente.']);
-    }
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
 }
-add_action('wp_ajax_get_latest_quiz_score', 'get_latest_quiz_score');
-add_action('wp_ajax_nopriv_get_latest_quiz_score', 'get_latest_quiz_score');
+
+if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-quiz-stats.php';
+}
+
+if ( ! class_exists( 'PoliteiaCourse' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-course.php';
+}
+
+function politeia_get_latest_quiz_activity() {
+    check_ajax_referer( 'politeia_quiz_activity', 'nonce' );
+
+    if ( ! is_user_logged_in() ) {
+        wp_send_json_error( 'No autorizado' );
+    }
+
+    $quiz_id = isset( $_POST['quiz_id'] ) ? intval( $_POST['quiz_id'] ) : 0;
+    $user_id = isset( $_POST['user_id'] ) ? intval( $_POST['user_id'] ) : 0;
+    $current = get_current_user_id();
+
+    if ( ! $quiz_id ) {
+        wp_send_json_error( 'Faltan datos' );
+    }
+
+    if ( $user_id && $user_id !== $current ) {
+        wp_send_json_error( 'Usuario no autorizado' );
+    }
+
+    $user_id = $user_id ?: $current;
+
+    $stats    = new Politeia_Quiz_Stats( $quiz_id, $user_id );
+    $summary  = $stats->get_quiz_summary( $quiz_id );
+    $response = [
+        'percentage'        => $summary['percentage'],
+        'percentage_rounded'=> $summary['percentage_rounded'],
+        'score'             => $summary['score'],
+        'timestamp'         => $summary['timestamp'],
+        'formatted_date'    => $summary['formatted_date'],
+        'course_id'         => $stats->get_course_id(),
+        'is_first_quiz'     => $stats->is_first_quiz(),
+        'is_final_quiz'     => $stats->is_final_quiz(),
+    ];
+
+    if ( $stats->is_final_quiz() ) {
+        $first_summary = $stats->get_first_quiz_summary();
+        $final_summary = $stats->get_final_quiz_summary();
+
+        $response['first_percentage'] = $first_summary['percentage_rounded'];
+        $response['final_percentage'] = $final_summary['percentage_rounded'];
+    }
+
+    if ( ! $summary['has_attempt'] ) {
+        wp_send_json_error( [ 'message' => 'Sin intentos' ] );
+    }
+
+    wp_send_json_success( $response );
+}
+add_action( 'wp_ajax_get_latest_quiz_activity', 'politeia_get_latest_quiz_activity' );
+add_action( 'wp_ajax_nopriv_get_latest_quiz_activity', 'politeia_get_latest_quiz_activity' );
+
+// Backwards compatibility: keep previous hook name but delegate to the new handler.
+function get_latest_quiz_score() {
+    politeia_get_latest_quiz_activity();
+}
+add_action( 'wp_ajax_get_latest_quiz_score', 'get_latest_quiz_score' );
+add_action( 'wp_ajax_nopriv_get_latest_quiz_score', 'get_latest_quiz_score' );

--- a/my-ld-course-override.php
+++ b/my-ld-course-override.php
@@ -10,6 +10,14 @@ if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
     require_once plugin_dir_path( __FILE__ ) . 'classes/class-course-quiz-helper.php';
 }
 
+if ( ! class_exists( 'PoliteiaCourse' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'classes/class-politeia-course.php';
+}
+
+if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'classes/class-politeia-quiz-stats.php';
+}
+
 // Reemplazar la plantilla del curso de LearnDash
 function my_custom_ld_course_template( $template ) {
     if ( is_singular( 'sfwd-courses' ) ) {
@@ -170,7 +178,7 @@ if ( is_singular( 'sfwd-quiz' ) ) {
     );
 
     $quiz_id      = get_the_ID();
-    $course_id    = CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+    $course_id    = PoliteiaCourse::getCourseFromQuiz( $quiz_id );
     $course_title = $course_id ? get_the_title( $course_id ) : '';
 
     // -----------------------------------------------------------
@@ -197,17 +205,18 @@ if ( is_singular( 'sfwd-quiz' ) ) {
 
 
     $quiz_description_raw = get_post_field('post_content', $quiz_id);
-$quiz_description = $quiz_description_raw ? apply_filters('the_content', do_blocks($quiz_description_raw)) : '';
+    $quiz_description = $quiz_description_raw ? apply_filters('the_content', do_blocks($quiz_description_raw)) : '';
 
-wp_localize_script( 'custom-quiz-message', 'quizData', [
-    'quizId'          => $quiz_id,
-    'userId'          => get_current_user_id(),
-    'courseName'      => $course_title,
-    'type'            => $type,
-    'description'     => $quiz_description,
-    'firstQuizNonce'  => $first_quiz_nonce,
-    'finalQuizNonce'  => $final_quiz_nonce,
-] );
+    wp_localize_script( 'custom-quiz-message', 'quizData', [
+        'quizId'          => $quiz_id,
+        'userId'          => get_current_user_id(),
+        'courseName'      => $course_title,
+        'type'            => $type,
+        'description'     => $quiz_description,
+        'firstQuizNonce'  => $first_quiz_nonce,
+        'finalQuizNonce'  => $final_quiz_nonce,
+        'activityNonce'   => wp_create_nonce( 'politeia_quiz_activity' ),
+    ] );
 
 
     // ajax_object.ajaxurl → para la llamada POST
@@ -359,7 +368,7 @@ function enviar_correo_first_quiz_handler() {
     $quiz_title = get_the_title($quiz_id);
 
     // Obtener Course ID desde la metadata configurada
-    $course_id = CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+    $course_id = PoliteiaCourse::getCourseFromQuiz( $quiz_id );
 
     // Verificar acceso al curso
     $tiene_acceso = $course_id ? sfwd_lms_has_access($course_id, $user_id) : false;
@@ -541,7 +550,7 @@ function handle_enviar_correo_final_quiz() {
 	$first_bar_style = $first_pct > 0 ? "width: {$first_pct}%; background-color: #ff9800;" : "width: 0%;" ;
 
 	// ---------- Preparar plantilla ----------
-        $course_id    = CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+        $course_id    = PoliteiaCourse::getCourseFromQuiz( $quiz_id );
         $course_title = $course_id ? get_the_title( $course_id ) : '';
 	$subject      = '¡Has completado el Final Quiz!';
 	$headers      = [ 'Content-Type: text/html; charset=UTF-8' ];

--- a/partials/ajax-results-box.php
+++ b/partials/ajax-results-box.php
@@ -3,8 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
-    require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+if ( ! class_exists( 'PoliteiaCourse' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-course.php';
 }
 
 $course_id = intval( $_POST['course_id'] ?? 0 );
@@ -87,8 +87,8 @@ function villegas_build_quiz_data( $wpdb, $attempt ) {
 // Datos del curso / quizzes
 // -----------------------------------------------------------------------------
 $course_title   = get_the_title( $course_id );
-$first_quiz_id  = CourseQuizMetaHelper::getFirstQuizId( $course_id );
-$final_quiz_id  = CourseQuizMetaHelper::getFinalQuizId( $course_id );
+$first_quiz_id  = PoliteiaCourse::getFirstQuizId( $course_id );
+$final_quiz_id  = PoliteiaCourse::getFinalQuizId( $course_id );
 
 $first_data = villegas_build_quiz_data(
     $wpdb,

--- a/parts/comprar-stats.php
+++ b/parts/comprar-stats.php
@@ -1,7 +1,7 @@
 <?php
 
-if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
-    require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+if ( ! class_exists( 'PoliteiaCourse' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-course.php';
 }
 ob_start();
 
@@ -92,7 +92,7 @@ function mostrar_comprar_stats() {
     }
 
     // First quiz ID and URL
-    $first_quiz_id = CourseQuizMetaHelper::getFirstQuizId( $course_id );
+    $first_quiz_id = PoliteiaCourse::getFirstQuizId( $course_id );
     $first_quiz_url = !empty($first_quiz_id) && ($quiz_post = get_post($first_quiz_id))
         ? home_url('/evaluaciones/' . $quiz_post->post_name . '/')
         : '#';
@@ -171,7 +171,7 @@ function mostrar_comprar_stats() {
                 <div id="final-test-button" class="tooltip" style="flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;">
                     <?php
                     global $wpdb;
-                    $final_quiz_id = CourseQuizMetaHelper::getFinalQuizId( $course_id );
+                    $final_quiz_id = PoliteiaCourse::getFinalQuizId( $course_id );
                     $final_quiz_url = $final_quiz_id ? get_permalink($final_quiz_id) : '';
 
                     $latest_attempt_final = $wpdb->get_row($wpdb->prepare(

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -1,741 +1,451 @@
 <?php
 /**
- * Displays Quiz Result Box (Legacy Template).
- *
- * @since 3.2.0
- * @version 4.17.0
+ * Custom quiz result box focused on "buy-button-stats" experience.
  */
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
+}
+
+if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-quiz-stats.php';
+}
+
+if ( ! class_exists( 'PoliteiaCourse' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-course.php';
+}
+
+global $post;
+$quiz_id = isset( $post->ID ) ? intval( $post->ID ) : 0;
+$user_id = get_current_user_id();
+$stats    = new Politeia_Quiz_Stats( $quiz_id, $user_id );
+
+$course_id       = $stats->get_course_id();
+$course_title    = $course_id ? get_the_title( $course_id ) : '';
+$is_first_quiz   = $stats->is_first_quiz();
+$is_final_quiz   = $stats->is_final_quiz();
+$current_summary = $stats->get_current_quiz_summary();
+$first_summary   = $stats->get_first_quiz_summary();
+$final_summary   = $stats->get_final_quiz_summary();
+
+$current_percentage = $current_summary['percentage_rounded'];
+$current_formatted  = $current_summary['formatted_date'] ?: date_i18n( 'j \d\e F \d\e Y' );
+
+$has_course    = (bool) $course_id;
+$has_access    = $has_course ? PoliteiaCourse::userHasAccess( $course_id, $user_id ) : false;
+$product_id    = $has_course ? PoliteiaCourse::getRelatedProductId( $course_id ) : 0;
+$product_url   = $product_id ? get_permalink( $product_id ) : '#';
+$course_url    = $has_course ? get_permalink( $course_id ) : '#';
+
+$comparison_available = $is_final_quiz
+    && $stats->get_first_quiz_id()
+    && $first_summary['has_attempt']
+    && $final_summary['has_attempt'];
+
+$progress_delta = null;
+$days_elapsed   = null;
+
+if ( $comparison_available ) {
+    $progress_delta = null;
+    if ( is_numeric( $final_summary['percentage_rounded'] ) && is_numeric( $first_summary['percentage_rounded'] ) ) {
+        $progress_delta = $final_summary['percentage_rounded'] - $first_summary['percentage_rounded'];
+    }
+
+    if ( $first_summary['timestamp'] && $final_summary['timestamp'] && $final_summary['timestamp'] >= $first_summary['timestamp'] ) {
+        $days_elapsed = max( 1, floor( ( $final_summary['timestamp'] - $first_summary['timestamp'] ) / DAY_IN_SECONDS ) );
+    }
+}
+
+$motivation_copy = '';
+if ( $is_first_quiz && is_numeric( $current_percentage ) ) {
+    if ( $current_percentage >= 80 ) {
+        $motivation_copy = sprintf(
+            '¡Excelente comienzo con %s%%! Imagina cuánto podrás reforzar tu conocimiento al acceder a todas las lecciones.',
+            $current_percentage
+        );
+    } elseif ( $current_percentage >= 50 ) {
+        $motivation_copy = sprintf(
+            'Tu puntaje de %s%% demuestra que ya conoces parte del contenido. Con el curso completo podrás dominarlo.',
+            $current_percentage
+        );
+    } else {
+        $motivation_copy = sprintf(
+            'Este es solo el inicio: con el curso completo podrás mejorar ampliamente ese %s%% obtenido en la Prueba Inicial.',
+            $current_percentage
+        );
+    }
+}
+
+$cta_text = $has_access ? 'Ir al curso' : 'Comprar curso';
+$cta_url  = $has_access ? $course_url : $product_url;
+
+if ( $is_final_quiz ) {
+    $cta_text = 'Ver resumen del curso';
+    $cta_url  = $course_url ? $course_url : home_url();
 }
 ?>
 <style>
-.learndash-wrapper .wpProQuiz_quiz_time {
+.politeia-quiz-results {
+    background: #ffffff;
+    border: 1px solid #d5d5d5;
+    border-radius: 12px;
+    padding: 24px;
+    margin-bottom: 24px;
+}
+.politeia-quiz-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: center;
+}
+.politeia-quiz-header h3 {
+    margin: 0;
+    font-size: 20px;
+}
+.politeia-quiz-meta {
     color: #728188;
-    font-size: .8em;
+    font-size: 14px;
+    font-weight: 600;
+}
+.politeia-quiz-chart {
+    margin: 30px auto;
+    max-width: 320px;
+}
+.politeia-score-highlight {
+    font-size: 32px;
     font-weight: 700;
-    background: white;
-    border: 1px solid #d5d5d5;
-    padding: 10px;
-    border-radius: 8px;
-    margin-bottom: 20px;
+    text-align: center;
 }
-
-.table-quiz-name {
-    text-align: left !important;
-}
-
-.quiz-results-container {
-    border: 1px solid #d5d5d5;
-    margin-bottom: 20px;
-}
-
-.extra-stats-container {
-    border: 1px solid #d5d5d5;
+.politeia-cta-box {
+    margin-top: 24px;
+    background: #f8f9fa;
+    border-radius: 10px;
     padding: 20px;
-    border-radius: 8px;
-    background: white;
 }
-
-.next-steps {
-    background: white;
-    padding: 40px;
+.politeia-cta-box p {
+    margin-top: 0;
+    margin-bottom: 16px;
+}
+.politeia-cta-box .politeia-button {
+    display: inline-block;
+    background: #000000;
+    color: #ffffff;
+    padding: 12px 20px;
+    border-radius: 6px;
+    font-weight: 600;
+    text-decoration: none;
+}
+.politeia-comparison {
+    margin-top: 30px;
+    border-top: 1px solid #e6e6e6;
+    padding-top: 24px;
+}
+.politeia-comparison-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 16px;
+}
+.politeia-comparison-card {
+    background: #f6f7f8;
+    padding: 18px;
+    border-radius: 10px;
+    text-align: center;
+}
+.politeia-comparison-card span {
+    display: block;
+    font-size: 14px;
+    color: #5f6b75;
+    margin-bottom: 6px;
+}
+.politeia-comparison-card strong {
+    font-size: 26px;
+}
+.politeia-comparison-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    justify-content: center;
+    margin-top: 18px;
+}
+.politeia-chip {
+    background: #eef0f2;
+    padding: 10px 16px;
+    border-radius: 30px;
+    font-weight: 600;
+    color: #333;
+}
+.politeia-quiz-attempt {
+    margin-top: 24px;
+    background: #ffffff;
     border: 1px solid #d5d5d5;
-    border-radius: 8px;
+    border-radius: 10px;
+    padding: 20px;
+    display: none;
 }
-
-.next-steps>h3 {
-    margin-top: 0px;
+.politeia-quiz-attempt h4 {
+    margin-top: 0;
 }
-
-.ld-quiz-actions {
+.politeia-quiz-attempt .politeia-comparison-grid {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+.learndash-wrapper .wpProQuiz_quiz_time,
+.learndash-wrapper .wpProQuiz_graded_points,
+.learndash-wrapper .wpProQuiz_certificate,
+.learndash-wrapper .wpProQuiz_resultTable,
+.learndash-wrapper .wpProQuiz_points,
+.learndash-wrapper .wpProQuiz_finishQuiz,
+.learndash-wrapper .wpProQuiz_solved {
     display: none !important;
 }
 </style>
 
-<!-- (A) LearnDash default sending container -->
-<div style="display: none;" class="wpProQuiz_sending">
-
+<div style="display:none;" class="wpProQuiz_sending">
     <p>
         <div>
-            <?php
-            echo wp_kses_post(
-                SFWD_LMS::get_template(
-                    'learndash_quiz_messages',
-                    array(
-                        'quiz_post_id' => $quiz->getID(),
-                        'context'      => 'quiz_complete_message',
-                        'message'      => sprintf(
-                            esc_html_x('%s complete. Results are being recorded.', 'placeholder: Quiz', 'learndash'),
-                            LearnDash_Custom_Label::get_label('quiz')
-                        ),
-                    )
-                )
-            );
-            ?>
+            <?php echo esc_html__( 'Quiz complete. Results are being recorded.', 'learndash' ); ?>
         </div>
         <div>
             <dd class="course_progress">
-                <div class="course_progress_blue sending_progress_bar" style="width: 0%;"></div>
+                <div class="course_progress_blue sending_progress_bar" style="width:0%"></div>
             </dd>
         </div>
     </p>
 </div>
 
-<!-- (B) LearnDash default results container -->
-<div style="display: none;" class="wpProQuiz_results">
-
-    <?php if (!$quiz->isHideResultCorrectQuestion()) :
-
-        // Show quiz time if not hidden.
-        if (!$quiz->isHideResultQuizTime()) { ?>
-            <p class="wpProQuiz_quiz_time">
-                <?php
-                echo wp_kses_post(
-                    SFWD_LMS::get_template(
-                        'learndash_quiz_messages',
-                        array(
-                            'quiz_post_id' => $quiz->getID(),
-                            'context'      => 'quiz_your_time_message',
-                            'message'      => sprintf(
-                                esc_html_x('Your time: %s', 'placeholder: quiz time.', 'learndash'),
-                                '<span></span>'
-                            ),
-                        )
-                    )
-                );
-                ?>
-            </p>
-        <?php } ?>
-
-        <div style="display: none;">
-            <span class="wpProQuiz_correct_answer">0</span>
-            <span class="total-questions"><?php echo intval($question_count); ?></span>
+<div style="display:none;" class="wpProQuiz_results">
+    <div class="politeia-quiz-results" data-quiz-id="<?php echo esc_attr( $quiz_id ); ?>">
+        <div class="politeia-quiz-header">
+            <div>
+                <h3><?php echo esc_html( get_the_title( $quiz_id ) ); ?></h3>
+                <div class="politeia-quiz-meta">
+                    <?php echo esc_html( $course_title ); ?> · <?php echo esc_html( $current_formatted ); ?>
+                </div>
+            </div>
+            <?php if ( $is_final_quiz && $first_summary['formatted_date'] ) : ?>
+                <div class="politeia-quiz-meta" style="text-align:right;">
+                    Prueba Inicial: <?php echo esc_html( $first_summary['formatted_date'] ); ?>
+                </div>
+            <?php endif; ?>
         </div>
 
-        <?php
-        global $post;
-        $quiz_id = isset($post->ID) ? $post->ID : 0;
-
-        if (!class_exists('QuizAnalytics')) {
-            require_once plugin_dir_path(__FILE__) . 'classes/class-quiz-analytics.php';
-        }
-
-        if (class_exists('QuizAnalytics')) {
-            $quiz_checker = new QuizAnalytics($quiz_id);
-            $is_first_quiz = $quiz_checker->isFirstQuiz(); // Método que determina si es First Quiz
-        } else {
-            $is_first_quiz = false;
-        }
-
-        // Usamos la función nativa de LearnDash para obtener el Course ID a partir del quiz.
-        $course_id = learndash_get_course_id($quiz_id);
-
-        // Determine the container ID for the current quiz.
-        $current_container_id = $is_first_quiz ? "quiz-results-container" : "final-quiz-results-container";
-        ?>
-        <!-- Current Quiz Results Container -->
-        <div id="<?php echo esc_attr($current_container_id); ?>" class="quiz-results-container responsive-quiz-box">
-            <div class="quiz-flex-item quiz-info">
-                <div class="quiz-name" style="font-weight: bold; font-size: 16px;">
-                    <?php echo esc_html(get_the_title()); ?>
-                </div>
-                <div style="color: #666; font-size: 14px;">
-                <?php echo esc_html(date_i18n('j \d\e F \d\e Y')); ?>
-                </div>
-            </div>
-
-            <div class="quiz-flex-item quiz-bar">
-                <div class="progress-bar-container" style="background: #e9ecef; border-radius: 15px; height: 20px; overflow: hidden;">
-                    <div id="quiz-progress-bar" style="width: 0%; height: 100%; background: #ff9800; transition: width 0.5s ease;"></div>
-                </div>
-            </div>
-
-            <div class="quiz-flex-item quiz-percentage">
-                <span id="quiz-percentage" style="font-size: 24px; font-weight: bold;">0%</span>
-            </div>
+        <div class="politeia-quiz-chart">
+            <div id="politeia-quiz-chart"></div>
         </div>
 
-        <style>
-        .responsive-quiz-box {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-between;
-            align-items: center;
-            background: white;
-            padding: 20px;
-            border-radius: 8px;
-            gap: 0;
-        }
-
-        .quiz-flex-item.quiz-info {
-            flex: 0 0 40%;
-            padding: 10px;
-            text-align: left;
-        }
-
-        .quiz-flex-item.quiz-bar {
-            flex: 0 0 40%;
-            padding: 10px;
-        }
-
-        .quiz-flex-item.quiz-percentage {
-            flex: 0 0 20%;
-            padding: 10px;
-            text-align: right;
-        }
-
-        /* Responsive: cambia a columna */
-        @media (max-width: 767px) {
-            .responsive-quiz-box {
-                flex-direction: column;
-                align-items: stretch;
-            }
-
-            .quiz-flex-item {
-                flex: 1 1 100%;
-                text-align: center !important;
-            }
-
-            .quiz-bar {
-                width: 100%;
-            }
-
-            .quiz-info {
-                text-align: center;
-            }
-        }
-        </style>
-
-        <?php
-        if (!defined('ABSPATH')) {
-            exit;
-        }
-
-        global $wpdb, $post;
-        $quiz_id = isset($post->ID) ? (int) $post->ID : 0;
-
-        if (!class_exists('QuizAnalytics')) {
-            require_once plugin_dir_path(__FILE__) . 'classes/class-quiz-analytics.php';
-        }
-
-        if (class_exists('QuizAnalytics')) {
-            $quiz_checker = new QuizAnalytics($quiz_id);
-            $is_first_quiz = $quiz_checker->isFirstQuiz(); // Determines if the current quiz is a First Quiz.
-        } else {
-            $is_first_quiz = false;
-        }
-
-        // Only process the button if the quiz is a First Quiz.
-        if ($is_first_quiz) {
-            // Retrieve the Course ID from the meta where _first_quiz_id equals the quiz ID.
-            $course_id = $wpdb->get_var(
-                $wpdb->prepare(
-                    "SELECT post_id
-                     FROM {$wpdb->postmeta}
-                     WHERE meta_key = '_first_quiz_id'
-                       AND meta_value = %d
-                     LIMIT 1",
-                    $quiz_id
-                )
-            );
-
-            // Retrieve the Product ID associated with the Course.
-            // First, try to get it from the '_linked_woocommerce_product' meta.
-            $product_id = get_post_meta($course_id, '_linked_woocommerce_product', true);
-            if (empty($product_id)) {
-                // If not found, search for a product with _related_course matching the Course ID.
-                $args = array(
-                    'post_type'      => 'product',
-                    'meta_query'     => array(
-                        array(
-                            'key'     => '_related_course',
-                            'value'   => $course_id,
-                            'compare' => 'LIKE',
-                        ),
-                    ),
-                    'posts_per_page' => 1,
-                );
-                $products = get_posts($args);
-                if (!empty($products)) {
-                    $product_id = $products[0]->ID;
-                }
-            }
-
-            // Generate URLs.
-            $course_url  = $course_id  ? get_permalink($course_id)  : '#';
-            $product_url = $product_id ? get_permalink($product_id) : '#';
-
-            // Check if the current user has access to the course.
-            $current_user = wp_get_current_user();
-            $user_id = $current_user->ID;
-            $has_access = sfwd_lms_has_access($course_id, $user_id);
-
-            // Set button text and URL based on access.
-            if ($has_access) {
-                $button_text = 'Ir al curso';
-                $button_url  = $course_url;
-            
-                // Texto para acceso permitido
-                ?>
-                <div class="next-steps" style="margin-bottom: 20px;">
-                    <h3>¿Qué pasos seguir ahora?</h3>
-                    <p>Ahora puedes proceder a completar todas las lecciones incluidas en este curso sobre <strong><?php echo esc_html(get_the_title($course_id)); ?></strong>.</p>
-                    <p>Una vez finalizadas, estarás listo para realizar la Prueba Final, que reflejará el progreso alcanzado durante el curso.</p>
-                    <p>Recuerda que puedes avanzar a tu propio ritmo: algunos estudiantes lo completan en un día, mientras que otros pueden tardar más.</p>
-                </div>
-                <?php
-            } else {
-                $button_text = 'Comprar curso';
-                $button_url  = $product_url;
-            
-                // Texto para acceso denegado
-                ?>
-                <div class="next-steps" style="margin-bottom: 20px;">
-                    <h3>Continúa tu aprendizaje</h3>
-                    <p>Ya has completado la Prueba Inicial, ahora puedes comprar el curso y acceder al contenido exclusivo sobre <strong><?php echo esc_html(get_the_title($course_id)); ?></strong>.</p>
-                    <p>Al finalizarlo, podrás rendir la Prueba Final y comparar tu progreso respecto a tu evaluación inicial.</p>
-                </div>
-                <?php
-            }
-            
-            ?>
-            <div id="testing-button" style="margin-top: 20px;">
-                <a href="<?php echo esc_url($button_url); ?>"
-                style="background-color: black; color: white; font-weight: 600; padding: 10px 15px; font-size: 14px; text-decoration: none; border-radius: 4px; display: inline-block;">
-                    <?php echo esc_html($button_text); ?>
-                </a>
-            </div>
-
-            <?php
-        }
-        ?>
-<?php
-if ( ! $is_first_quiz ) {
-
-    /* ------------------------------------------------------------------
-     * 1) Información del First Quiz
-     * ------------------------------------------------------------------*/
-    $first_quiz_id    = $quiz_checker->getFirstQuiz();
-    $first_quiz_name  = ( $first_quiz_id && $first_quiz_id !== "Doesn't have" )
-        ? get_the_title( $first_quiz_id )
-        : "Doesn't exist";
-
-    $perf                   = $quiz_checker->getFirstQuizPerformance();
-    $first_quiz_percentage  = is_numeric( $perf['percentage'] )
-        ? round( floatval( $perf['percentage'] ) )
-        : 0;
-
-    // ✅ Timestamp ya corregido en QuizAnalytics (activity_completed || activity_started)
-    $first_quiz_date_ts = (int) $quiz_checker->getFirstQuizTimestamp();
-
-
-    /* ------------------------------------------------------------------
-     * 2) Información del Final Quiz (último intento registrado)
-     * ------------------------------------------------------------------*/
-    global $wpdb;
-    $user_id       = get_current_user_id();
-
-    $final_attempt = $wpdb->get_row(
-        $wpdb->prepare(
-            "SELECT activity_completed
-               FROM {$wpdb->prefix}learndash_user_activity
-              WHERE user_id       = %d
-                AND post_id       = %d
-                AND activity_type = 'quiz'
-           ORDER BY activity_completed DESC
-              LIMIT 1",
-            $user_id,
-            $quiz_id
-        )
-    );
-
-    $final_quiz_date_ts = ! empty( $final_attempt->activity_completed )
-        ? (int) $final_attempt->activity_completed
-        : null;
-
-
-    /* ------------------------------------------------------------------
-     * 3) Diferencia de días (mínimo 1 día si ambas fechas existen)
-     * ------------------------------------------------------------------*/
-    $days_diff = 1;   // Valor por defecto
-    if ( $first_quiz_date_ts && $final_quiz_date_ts ) {
-        $diff_seconds   = $final_quiz_date_ts - $first_quiz_date_ts;
-        $calculated     = floor( $diff_seconds / DAY_IN_SECONDS );
-        $days_diff      = max( 1, $calculated );
-    }
-
-            ?>
-
-            <!-- First Quiz Results Container -->
-            <div id="first-quiz-results-container" class="quiz-results-container responsive-quiz-box" style="margin-top: 20px;">
-                <div class="quiz-flex-item quiz-info">
-                    <div class="quiz-name" style="font-weight: bold; font-size: 16px;">
-                        <?php echo esc_html($first_quiz_name); ?>
-                    </div>
-                    <div style="color: #666; font-size: 14px;">
-                        <?php echo $first_quiz_date_ts ? esc_html(date_i18n('j \d\e F \d\e Y', $first_quiz_date_ts)) : 'N/A'; ?>
-                    </div>
-                </div>
-
-                <div class="quiz-flex-item quiz-bar">
-                    <div class="progress-bar-container" style="background: #e9ecef; border-radius: 15px; height: 20px; overflow: hidden;">
-                        <div id="first-quiz-progress-bar"
-                             style="width: <?php echo esc_attr($first_quiz_percentage); ?>%; height: 100%; background: #ff9800; transition: width 0.5s ease;">
-                        </div>
-                    </div>
-                </div>
-
-                <div class="quiz-flex-item quiz-percentage">
-                    <span id="first-quiz-percentage" style="font-size: 24px; font-weight: bold;">
-                        <?php echo esc_html($first_quiz_percentage); ?>%
-                    </span>
-                </div>
-            </div>
-
-            <!-- Extra stats block (variación de conocimiento y días para completar) -->
-            <div class="extra-stats-container" style="margin-top: 20px;">
-                <div style="display: flex; justify-content: space-evenly; align-items: center;">
-                    <div style="flex: 1; text-align: center;">
-                        <div style="font-size: 16px; color: #666;">Variación conocimientos</div>
-                        <div id="knowledge-variation" style="font-size: 36px; color: #9fd99f; font-weight: bold;">
-                            0% <span style="font-size: 28px;">▲</span>
-                        </div>
-                    </div>
-                    <div style="flex: 1; text-align: center;">
-                        <div style="font-size: 16px; color: #666;">Completaste el curso en</div>
-                        <div style="font-size: 36px; color: #333; font-weight: bold;">
-                            <?php
-                            $dias = intval($days_diff);
-                            // Display "1 día" only if started and finished on the same day (days_diff = 0)
-                            if ($dias === 0 && $first_quiz_date_ts && $final_quiz_date_ts) {
-                                echo '1 día';
-                            } else {
-                                echo $dias . ' ' . ($dias === 1 ? 'día' : 'días');
-                            }
-                            ?>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <script>
-                document.addEventListener("DOMContentLoaded", function() {
-                    // Al finalizar el quiz, actualizar la barra de progreso y calcular la variación.
-                    jQuery(document).on('learndash-quiz-finished', function() {
-                        var correctAnswers = parseInt(jQuery('.wpProQuiz_correct_answer').text(), 10);
-                        var totalQuestions = parseInt(jQuery('.total-questions').text(), 10);
-                        if (!isNaN(correctAnswers) && totalQuestions > 0) {
-                            var finalPct = Math.round((correctAnswers / totalQuestions) * 100);
-                            jQuery('#quiz-percentage').text(finalPct + '%');
-                            jQuery('#quiz-progress-bar').css('width', finalPct + '%');
-
-                            // Obtener el porcentaje del First Quiz
-                            var firstQuizPct = <?php echo json_encode($first_quiz_percentage); ?>;
-                            var variation = finalPct - firstQuizPct;
-                            var arrow = variation >= 0 ? '▲' : '▼';
-                            var color = variation >= 0 ? '#9fd99f' : 'red';
-
-                            jQuery('#knowledge-variation')
-                                .css('color', color)
-                                .html(Math.abs(variation) + '% <span style="font-size: 28px;">' + arrow + '</span>');
-                        }
-                    });
-                    // Ajustar el ancho inicial de la barra del First Quiz.
-                    var pct = <?php echo json_encode(str_replace('%', '', $first_quiz_percentage)); ?>;
-                    document.getElementById("first-quiz-progress-bar").style.width = pct + "%";
-                });
-            </script>
-        <?php
-        }
-
-
-$user_id = get_current_user_id();
-$puntaje_privado = get_user_meta($user_id, 'puntaje_privado', true);
-$is_checked = ($puntaje_privado === '1' || $puntaje_privado === 1) ? 'checked' : '';
-?>
-<div class="quiz-private-toggle" style="background: #f9f9f9; padding: 15px; border-radius: 8px; text-align: center;">
-    <label style="font-size: 15px; font-weight: 500;">
-    <input type="checkbox" id="puntaje_privado_checkbox" data-user-id="<?php echo get_current_user_id(); ?>" <?php echo $is_checked; ?>>
-        No mostrar mi puntaje en rankings públicos
-    </label>
-</div>
-
-
-<?php
-        // Opcional: configurar la fecha de finalización del Final Quiz.
-        global $wpdb;
-        $user_id = get_current_user_id();
-        if (!$is_first_quiz) {
-            $final_attempt = $wpdb->get_row(
-                $wpdb->prepare(
-                    "SELECT activity_completed
-                    FROM {$wpdb->prefix}learndash_user_activity
-                    WHERE user_id = %d
-                      AND post_id = %d
-                      AND activity_type = 'quiz'
-                    ORDER BY activity_completed DESC
-                    LIMIT 1",
-                    $user_id,
-                    $quiz_id
-                )
-            );
-            if (!empty($final_attempt)) {
-                if (!isset($quiz)) {
-                    $quiz = new stdClass();
-                }
-                $quiz->completed_date = date('Y-m-d H:i:s', (int) $final_attempt->activity_completed);
-            }
-        }
-        ?>
-
-        <script>
-        // Definir ajaxurl y si es First Quiz
-        var ajaxurl = "<?php echo admin_url('admin-ajax.php'); ?>";
-        var isFirstQuiz = <?php echo $is_first_quiz ? 'true' : 'false'; ?>;
-
-        jQuery(document).ready(function($) {
-            const firstQuizNonce = (typeof quizData !== 'undefined' && quizData.firstQuizNonce) ? quizData.firstQuizNonce : '';
-
-            $(document).on('learndash-quiz-finished', function() {
-                var correctAnswers = parseInt($('.wpProQuiz_correct_answer').text(), 10);
-                var totalQuestions = parseInt($('.total-questions').text(), 10);
-
-                if (!isNaN(correctAnswers) && totalQuestions > 0) {
-                    var percentage = Math.round((correctAnswers / totalQuestions) * 100);
-                    $('#quiz-percentage').text(percentage + '%');
-                    $('#quiz-progress-bar').css('width', percentage + '%');
-
-                    if (isFirstQuiz) {
-                        $.post(ajaxurl, {
-                            action: 'enviar_correo_first_quiz',
-                            quiz_percentage: percentage,
-                            quiz_id: <?php echo (int)$quiz_id; ?>,
-                            nonce: firstQuizNonce
-                        }, function(response) {
-                            console.log('Correo enviado (First Quiz):', response);
-                        });
-                    }
-                    // IMPORTANTE: No hacer nada aquí si es Final Quiz.
-                }
-            });
-        });
-
-        </script>
-
-    <?php endif; ?>
-
-    <p class="wpProQuiz_time_limit_expired" style="display: none;">
-        <?php
-        echo wp_kses_post(
-            SFWD_LMS::get_template(
-                'learndash_quiz_messages',
-                array(
-                    'quiz_post_id' => $quiz->getID(),
-                    'context'      => 'quiz_time_has_elapsed_message',
-                    'message'      => esc_html__('Time has elapsed', 'learndash'),
-                )
-            )
-        );
-        ?>
-    </p>
-
-    <?php
-    // Bloque de resultados basados en puntos.
-    if (!$quiz->isHideResultPoints()) { ?>
-        <p class="wpProQuiz_graded_points" style="display: none;">
-            <?php
-            echo wp_kses_post(
-                SFWD_LMS::get_template(
-                    'learndash_quiz_messages',
-                    array(
-                        'quiz_post_id' => $quiz->getID(),
-                        'context'      => 'quiz_earned_points_message',
-                        'message'      => sprintf(
-                            esc_html_x('Earned Point(s): %1$s of %2$s, (%3$s)', 'placeholder: points earned, points total, points percentage', 'learndash'),
-                            '<span>0</span>',
-                            '<span>0</span>',
-                            '<span>0</span>'
-                        ),
-                        'placeholders' => array('0', '0', '0'),
-                    )
-                )
-            );
-            ?>
-        </p>
-    <?php }
-
-    if (is_user_logged_in()) { ?>
-        <p class="wpProQuiz_certificate" style="display: none;"><?php echo LD_QuizPro::certificate_link('', $quiz); ?></p>
-        <?php echo LD_QuizPro::certificate_details($quiz); ?>
-    <?php }
-
-    if ($quiz->isShowAverageResult()) { ?>
-        <div class="wpProQuiz_resultTable">
-            <table>
-                <tbody>
-                    <tr>
-                        <td class="wpProQuiz_resultName">
-                            <?php
-                            echo wp_kses_post(
-                                SFWD_LMS::get_template(
-                                    'learndash_quiz_messages',
-                                    array(
-                                        'quiz_post_id' => $quiz->getID(),
-                                        'context'      => 'quiz_average_score_message',
-                                        'message'      => esc_html__('Average score', 'learndash'),
-                                    )
-                                )
-                            );
-                            ?>
-                        </td>
-                        <td class="wpProQuiz_resultValue wpProQuiz_resultValue_AvgScore">
-                            <div class="progress-meter" style="background-color: #6CA54C;"> </div>
-                            <span class="progress-number"> </span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td class="wpProQuiz_resultName">
-                            <?php
-                            echo wp_kses_post(
-                                SFWD_LMS::get_template(
-                                    'learndash_quiz_messages',
-                                    array(
-                                        'quiz_post_id' => $quiz->getID(),
-                                        'context'      => 'quiz_your_score_message',
-                                        'message'      => esc_html__('Your score', 'learndash'),
-                                    )
-                                )
-                            );
-                            ?>
-                        </td>
-                        <td class="wpProQuiz_resultValue wpProQuiz_resultValue_YourScore">
-                            <div class="progress-meter"> </div>
-                            <span class="progress-number"> </span>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+        <div class="politeia-score-highlight">
+            <span id="quiz-percentage">
+                <?php echo is_numeric( $current_percentage ) ? esc_html( $current_percentage ) : '0'; ?>%
+            </span>
         </div>
-    <?php } ?>
 
-    <div class="wpProQuiz_catOverview" <?php $quiz_view->isDisplayNone($quiz->isShowCategoryScore()); ?>>
-        <h4>
-            <?php
-            echo wp_kses_post(
-                SFWD_LMS::get_template(
-                    'learndash_quiz_messages',
-                    array(
-                        'quiz_post_id' => $quiz->getID(),
-                        'context'      => 'learndash_categories_header',
-                        'message'      => esc_html__('Categories', 'learndash'),
-                    )
-                )
-            );
-            ?>
-        </h4>
-        <div style="margin-top: 10px;">
-            <ol>
-                <?php
-                foreach ($quiz_view->category as $cat) {
-                    if (!$cat->getCategoryId()) {
-                        $cat->setCategoryName(
-                            wp_kses_post(
-                                SFWD_LMS::get_template(
-                                    'learndash_quiz_messages',
-                                    array(
-                                        'quiz_post_id' => $quiz->getID(),
-                                        'context'      => 'learndash_not_categorized_messages',
-                                        'message'      => esc_html__('Not categorized', 'learndash'),
-                                    )
-                                )
-                            )
-                        );
-                    }
-                    ?>
-                    <li data-category_id="<?php echo esc_attr($cat->getCategoryId()); ?>">
-                        <span class="wpProQuiz_catName"><?php echo esc_attr($cat->getCategoryName()); ?></span>
-                        <span class="wpProQuiz_catPercent">0%</span>
-                    </li>
-                    <?php
-                }
-                ?>
-            </ol>
+        <?php if ( $is_first_quiz ) : ?>
+            <div class="politeia-cta-box">
+                <?php if ( $motivation_copy ) : ?>
+                    <p><?php echo esc_html( $motivation_copy ); ?></p>
+                <?php endif; ?>
+                <?php if ( $has_course ) : ?>
+                    <a class="politeia-button" href="<?php echo esc_url( $cta_url ); ?>">
+                        <?php echo esc_html( $cta_text ); ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+        <?php elseif ( $comparison_available ) : ?>
+            <div class="politeia-comparison">
+                <h4>Comparativa con tu Prueba Inicial</h4>
+                <div class="politeia-comparison-grid">
+                    <div class="politeia-comparison-card">
+                        <span>Prueba Inicial</span>
+                        <strong>
+                            <?php
+                            echo is_numeric( $first_summary['percentage_rounded'] )
+                                ? esc_html( $first_summary['percentage_rounded'] ) . '%'
+                                : '--';
+                            ?>
+                        </strong>
+                    </div>
+                    <div class="politeia-comparison-card">
+                        <span>Prueba Final</span>
+                        <strong id="politeia-final-score">
+                            <?php
+                            echo is_numeric( $final_summary['percentage_rounded'] )
+                                ? esc_html( $final_summary['percentage_rounded'] ) . '%'
+                                : '--';
+                            ?>
+                        </strong>
+                    </div>
+                </div>
+                <div class="politeia-comparison-meta">
+                    <?php if ( ! is_null( $progress_delta ) ) : ?>
+                        <div class="politeia-chip">
+                            Progreso: <?php echo $progress_delta >= 0 ? '+' : ''; ?><?php echo esc_html( $progress_delta ); ?>%
+                        </div>
+                    <?php endif; ?>
+                    <?php if ( ! is_null( $days_elapsed ) ) : ?>
+                        <div class="politeia-chip">
+                            Días transcurridos: <?php echo esc_html( $days_elapsed ); ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+                <?php if ( $has_course ) : ?>
+                    <div style="text-align:center; margin-top:20px;">
+                        <a class="politeia-button" href="<?php echo esc_url( $cta_url ); ?>"><?php echo esc_html( $cta_text ); ?></a>
+                    </div>
+                <?php endif; ?>
+            </div>
+        <?php endif; ?>
+
+        <div id="politeia-quiz-attempt" class="politeia-quiz-attempt">
+            <h4>Datos del Intento</h4>
+            <div class="politeia-comparison-grid">
+                <div class="politeia-comparison-card">
+                    <span>Puntaje obtenido</span>
+                    <strong id="politeia-attempt-percentage">--%</strong>
+                </div>
+                <div class="politeia-comparison-card">
+                    <span>Fecha de intento</span>
+                    <strong id="politeia-attempt-date">--</strong>
+                </div>
+            </div>
         </div>
     </div>
-    <div>
-        <ul class="wpProQuiz_resultsList">
-            <?php
-            foreach ($result['text'] as $resultText) { ?>
-                <li style="display: none;">
-                    <div>
-                        <?php
-                        if ($quiz->is_result_message_enabled()) {
-                            echo do_shortcode(apply_filters('comment_text', $resultText, null, null));
-                        }
-                        ?>
-                    </div>
-                </li>
-            <?php } ?>
-        </ul>
-    </div>
+
     <?php
-    if ($quiz->isToplistActivated()) {
-        if ($quiz->getToplistDataShowIn() == WpProQuiz_Model_Quiz::QUIZ_TOPLIST_SHOW_IN_NORMAL) {
-            echo do_shortcode('[LDAdvQuiz_toplist ' . $quiz->getId() . ' q="true"]');
-        }
-        $quiz_view->showAddToplist();
-    }
+    $user_private_score = get_user_meta( $user_id, 'puntaje_privado', true );
+    $is_checked         = ( '1' === $user_private_score || 1 === (int) $user_private_score ) ? 'checked' : '';
     ?>
-    <div class="ld-quiz-actions" style="margin: 10px 0px;">
-        <?php
-        $show_quiz_continue_buttom_on_fail = apply_filters('show_quiz_continue_buttom_on_fail', false, learndash_get_quiz_id_by_pro_quiz_id($quiz->getId()));
-        ?>
-        <div class='quiz_continue_link <?php if (true === $show_quiz_continue_buttom_on_fail) { echo ' show_quiz_continue_buttom_on_fail'; } ?>'></div>
-        <?php if (!$quiz->isBtnRestartQuizHidden()) { ?>
-            <input class="wpProQuiz_button wpProQuiz_button_restartQuiz" type="button" name="restartQuiz"
-                   value="<?php echo wp_kses_post(
-                       SFWD_LMS::get_template(
-                           'learndash_quiz_messages',
-                           array(
-                               'quiz_post_id' => $quiz->getID(),
-                               'context'      => 'quiz_restart_button_label',
-                               'message'      => sprintf(
-                                   esc_html_x('Restart %s', 'Restart Quiz Button Label', 'learndash'),
-                                   LearnDash_Custom_Label::get_label('quiz')
-                               ),
-                           )
-                       )
-                   ); ?>"/>
-        <?php } ?>
-        <?php if (!$quiz->isBtnViewQuestionHidden()) { ?>
-            <input class="wpProQuiz_button wpProQuiz_button_reShowQuestion" type="button" name="reShowQuestion"
-                   value="<?php echo wp_kses_post(
-                       SFWD_LMS::get_template(
-                           'learndash_quiz_messages',
-                           array(
-                               'quiz_post_id' => $quiz->getID(),
-                               'context'      => 'quiz_view_questions_button_label',
-                               'message'      => sprintf(
-                                   esc_html_x('View %s', 'View Questions Button Label', 'learndash'),
-                                   LearnDash_Custom_Label::get_label('questions')
-                               ),
-                           )
-                       )
-                   ); ?>"/>
-        <?php } ?>
-        <?php if ($quiz->isToplistActivated() && $quiz->getToplistDataShowIn() == WpProQuiz_Model_Quiz::QUIZ_TOPLIST_SHOW_IN_BUTTON) { ?>
-            <input class="wpProQuiz_button" type="button" name="showToplist"
-                   value="<?php echo wp_kses_post(
-                       SFWD_LMS::get_template(
-                           'learndash_quiz_messages',
-                           array(
-                               'quiz_post_id' => $quiz->getID(),
-                               'context'      => 'quiz_show_leaderboard_button_label',
-                               'message'      => esc_html__('Show leaderboard', 'learndash'),
-                           )
-                       )
-                   ); ?>"/>
-        <?php } ?>
+    <div class="quiz-private-toggle" style="background:#f9f9f9;padding:15px;border-radius:8px;text-align:center;margin-top:16px;">
+        <label style="font-size:15px;font-weight:500;">
+            <input type="checkbox" id="puntaje_privado_checkbox" data-user-id="<?php echo esc_attr( $user_id ); ?>" <?php echo esc_attr( $is_checked ); ?>>
+            No mostrar mi puntaje en rankings públicos
+        </label>
     </div>
 </div>
+
+<script>
+(function($){
+    const quizConfig = {
+        quizId: <?php echo (int) $quiz_id; ?>,
+        userId: <?php echo (int) $user_id; ?>,
+        isFinalQuiz: <?php echo $is_final_quiz ? 'true' : 'false'; ?>,
+        firstScore: <?php echo is_numeric( $first_summary['percentage_rounded'] ) ? (int) $first_summary['percentage_rounded'] : 0; ?>,
+        nonce: (typeof quizData !== 'undefined' && quizData.activityNonce) ? quizData.activityNonce : ''
+    };
+
+    let chartInstance = null;
+
+    function renderChart(series, labels) {
+        const chartEl = document.querySelector('#politeia-quiz-chart');
+        if (!chartEl || typeof ApexCharts === 'undefined') {
+            return;
+        }
+
+        if (chartInstance) {
+            chartInstance.updateOptions({ series: series, labels: labels });
+            return;
+        }
+
+        const options = {
+            chart: {
+                type: 'radialBar',
+                height: 320,
+                fontFamily: 'inherit'
+            },
+            colors: ['#ff9800', '#9fd99f'],
+            series: series,
+            labels: labels,
+            plotOptions: {
+                radialBar: {
+                    hollow: { size: '60%' },
+                    dataLabels: {
+                        name: { fontSize: '14px' },
+                        value: { fontSize: '24px', formatter: function(val){ return Math.round(val) + '%'; } }
+                    }
+                }
+            }
+        };
+
+        chartInstance = new ApexCharts(chartEl, options);
+        chartInstance.render();
+    }
+
+    function updateAttemptUI(data) {
+        if (!data || typeof data !== 'object') {
+            return;
+        }
+
+        const attemptBox = $('#politeia-quiz-attempt');
+        const attemptPercentage = (typeof data.percentage === 'number') ? data.percentage : 0;
+        $('#politeia-attempt-percentage').text(attemptPercentage + '%');
+        $('#politeia-attempt-date').text(data.formatted_date || '--');
+        $('#quiz-percentage').text(attemptPercentage + '%');
+
+        if (quizConfig.isFinalQuiz) {
+            const finalValue = (typeof data.final_percentage === 'number') ? data.final_percentage : attemptPercentage;
+            $('#politeia-final-score').text(finalValue + '%');
+        }
+
+        if (attemptBox.length) {
+            attemptBox.slideDown();
+        }
+
+        if (chartInstance) {
+            const finalSeriesValue = (typeof data.final_percentage === 'number') ? data.final_percentage : attemptPercentage;
+            const firstSeriesValue = (typeof data.first_percentage === 'number') ? data.first_percentage : quizConfig.firstScore;
+            const newSeries = quizConfig.isFinalQuiz
+                ? [finalSeriesValue, firstSeriesValue]
+                : [attemptPercentage];
+            chartInstance.updateSeries(newSeries);
+        }
+    }
+
+    function pollLatestAttempt(retries) {
+        if (!quizConfig.nonce) {
+            return;
+        }
+
+        $.post(ajax_object.ajaxurl, {
+            action: 'get_latest_quiz_activity',
+            quiz_id: quizConfig.quizId,
+            user_id: quizConfig.userId,
+            nonce: quizConfig.nonce
+        }).done(function(response){
+            if (response && response.success) {
+                const payload = response.data || {};
+                updateAttemptUI({
+                    percentage: (typeof payload.percentage_rounded === 'number') ? payload.percentage_rounded : payload.percentage,
+                    formatted_date: payload.formatted_date,
+                    final_percentage: payload.final_percentage,
+                    first_percentage: payload.first_percentage
+                });
+            } else if (retries > 0) {
+                setTimeout(function(){ pollLatestAttempt(retries - 1); }, 1500);
+            }
+        }).fail(function(){
+            if (retries > 0) {
+                setTimeout(function(){ pollLatestAttempt(retries - 1); }, 1500);
+            }
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', function(){
+        const baseSeries = quizConfig.isFinalQuiz
+            ? [<?php echo is_numeric( $final_summary['percentage_rounded'] ) ? (int) $final_summary['percentage_rounded'] : 0; ?>, quizConfig.firstScore]
+            : [<?php echo is_numeric( $current_percentage ) ? (int) $current_percentage : 0; ?>];
+        const baseLabels = quizConfig.isFinalQuiz ? ['Prueba Final', 'Prueba Inicial'] : ['Resultado'];
+        renderChart(baseSeries, baseLabels);
+
+        if (<?php echo $current_summary['has_attempt'] ? 'true' : 'false'; ?>) {
+            updateAttemptUI({
+                percentage: <?php echo is_numeric( $current_percentage ) ? (int) $current_percentage : 0; ?>,
+                formatted_date: <?php echo wp_json_encode( $current_summary['formatted_date'] ); ?>,
+                final_percentage: <?php echo is_numeric( $final_summary['percentage_rounded'] ) ? (int) $final_summary['percentage_rounded'] : 'null'; ?>,
+                first_percentage: quizConfig.firstScore
+            });
+        }
+    });
+
+    $(document).on('learndash-quiz-finished', function(){
+        pollLatestAttempt(6);
+    });
+})(jQuery);
+</script>


### PR DESCRIPTION
## Summary
- add PoliteiaCourse and Politeia_Quiz_Stats helpers to resolve first/final quizzes from course metadata
- rebuild the quiz result box template to use the new helpers, render CTA logic, and display comparison analytics
- update supporting PHP and AJAX handlers to fetch quiz activity via metadata IDs instead of LearnDash course steps

## Testing
- php -l classes/class-politeia-course.php
- php -l classes/class-politeia-quiz-stats.php
- php -l templates/show_quiz_result_box.php
- php -l includes/ajax-handlers.php
- php -l my-ld-course-override.php


------
https://chatgpt.com/codex/tasks/task_e_68dfc59054f48332a83480ef5887b732