### PR TITLE
Refactor quiz results to use course quiz metadata

### DIFF
--- a/partials/ajax-results-box.php
+++ b/partials/ajax-results-box.php
@@ -3,169 +3,209 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! class_exists( 'PoliteiaCourse' ) ) {
-    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-course.php';
+$modal_data = isset( $modal_data ) && is_array( $modal_data ) ? $modal_data : [];
+
+$course_title = isset( $modal_data['course']['title'] ) ? $modal_data['course']['title'] : '';
+$first        = isset( $modal_data['first'] ) ? $modal_data['first'] : [];
+$final        = isset( $modal_data['final'] ) ? $modal_data['final'] : [];
+$metrics      = isset( $modal_data['metrics'] ) ? $modal_data['metrics'] : [];
+
+$messages = [];
+
+if ( empty( $first['quiz_id'] ) ) {
+    $messages[] = __( 'Este curso no tiene configurada una Prueba Inicial.', 'villegas-courses' );
 }
 
-$course_id = intval( $_POST['course_id'] ?? 0 );
-$user_id   = get_current_user_id();
-
-if ( ! $course_id || ! $user_id ) {
-    echo '<p>Error: faltan datos.</p>';
-    return;
+if ( empty( $final['quiz_id'] ) ) {
+    $messages[] = __( 'Este curso no tiene configurada una Prueba Final.', 'villegas-courses' );
 }
 
-// -----------------------------------------------------------------------------
-// Utilidades
-// -----------------------------------------------------------------------------
-global $wpdb;
-
-/**
- * Devuelve el último intento de un quiz (o null si no hay intento).
- */
-function villegas_last_quiz_attempt( $wpdb, $user_id, $quiz_id ) {
-    if ( ! $quiz_id ) {
-        return null;
-    }
-
-    return $wpdb->get_row(
-        $wpdb->prepare(
-            "SELECT activity_id, activity_completed
-             FROM {$wpdb->prefix}learndash_user_activity
-             WHERE user_id   = %d
-               AND post_id   = %d
-               AND activity_type = 'quiz'
-             ORDER BY activity_completed DESC
-             LIMIT 1",
-            $user_id,
-            $quiz_id
-        )
-    );
+if ( ! empty( $first['quiz_id'] ) && empty( $first['has_attempt'] ) ) {
+    $messages[] = __( 'Aún no registramos resultados de tu Prueba Inicial.', 'villegas-courses' );
 }
 
-/**
- * Construye un array normalizado con % y fecha formateada.
- */
-function villegas_build_quiz_data( $wpdb, $attempt ) {
-    $data = [
-        'pct'            => 0,
-        'date'           => null,
-        'formatted_date' => 'N/A',
-    ];
-
-    if ( ! $attempt ) {  // no hay intento
-        return $data;
-    }
-
-    // 1. Porcentaje
-    $pct = $wpdb->get_var(
-        $wpdb->prepare(
-            "SELECT activity_meta_value
-             FROM {$wpdb->prefix}learndash_user_activity_meta
-             WHERE activity_id       = %d
-               AND activity_meta_key = 'percentage'",
-            $attempt->activity_id
-        )
-    );
-    $data['pct'] = round( floatval( $pct ) );
-
-    // 2. Timestamp: si activity_completed es 0, usamos activity_started
-    $timestamp = intval( $attempt->activity_completed );
-    if ( $timestamp === 0 ) {
-        $timestamp = intval( $attempt->activity_started );
-    }
-    $data['date'] = $timestamp;
-
-    if ( $timestamp > 0 ) {
-        $data['formatted_date'] = date_i18n( 'j \d\e F \d\e Y', $timestamp );
-    }
-    return $data;
+if ( ! empty( $final['quiz_id'] ) && empty( $final['has_attempt'] ) ) {
+    $messages[] = __( 'Aún no registramos resultados de tu Prueba Final.', 'villegas-courses' );
 }
 
+$show_comparison = empty( $messages ) && ! empty( $first['has_attempt'] ) && ! empty( $final['has_attempt'] );
 
-// -----------------------------------------------------------------------------
-// Datos del curso / quizzes
-// -----------------------------------------------------------------------------
-$course_title   = get_the_title( $course_id );
-$first_quiz_id  = PoliteiaCourse::getFirstQuizId( $course_id );
-$final_quiz_id  = PoliteiaCourse::getFinalQuizId( $course_id );
-
-$first_data = villegas_build_quiz_data(
-    $wpdb,
-    villegas_last_quiz_attempt( $wpdb, $user_id, $first_quiz_id )
-);
-
-$final_data = villegas_build_quiz_data(
-    $wpdb,
-    villegas_last_quiz_attempt( $wpdb, $user_id, $final_quiz_id )
-);
-
-if ( $first_data['date'] === null || $final_data['date'] === null ) {
-    echo '<p>Faltan resultados para mostrar comparativa.</p>';
-    return;
-}
-
-// Variación y días
-$variation = $final_data['pct'] - $first_data['pct'];
-$days_diff = max( 1, floor( ( $final_data['date'] - $first_data['date'] ) / DAY_IN_SECONDS ) );
+$first_percentage = isset( $first['percentage'] ) ? $first['percentage'] : null;
+$final_percentage = isset( $final['percentage'] ) ? $final['percentage'] : null;
+$variation        = isset( $metrics['delta'] ) ? $metrics['delta'] : null;
+$days_elapsed     = isset( $metrics['days_elapsed'] ) ? $metrics['days_elapsed'] : null;
 ?>
 <style>
-.quiz-results-container,
-.extra-stats-container{
-    border:1px solid #d5d5d5;
-    padding:20px;
-    border-radius:8px;
-    background:#fff;
-    margin-bottom:20px;
-}
-.quiz-flex{display:flex;justify-content:space-between;align-items:center;}
-.quiz-name{font-weight:bold;font-size:16px;}
-.quiz-percentage{font-size:24px;font-weight:bold;text-align:right;}
+    .politeia-modal-results {
+        background: #ffffff;
+        border-radius: 12px;
+        padding: 24px;
+        box-shadow: 0 12px 40px rgba(0,0,0,0.1);
+        max-width: 640px;
+        margin: 0 auto;
+        position: relative;
+    }
+    .politeia-modal-results h3 {
+        margin-top: 0;
+        text-align: center;
+        font-size: 22px;
+    }
+    .politeia-modal-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 16px;
+        margin-top: 24px;
+    }
+    .politeia-modal-card {
+        background: #f8f9fa;
+        padding: 18px;
+        border-radius: 10px;
+    }
+    .politeia-modal-card span {
+        display: block;
+        color: #728188;
+        font-weight: 600;
+        margin-bottom: 8px;
+    }
+    .politeia-modal-card strong {
+        font-size: 30px;
+        font-weight: 700;
+        display: block;
+    }
+    .politeia-modal-meta {
+        margin-top: 20px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        justify-content: center;
+    }
+    .politeia-modal-chip {
+        background: #eef0f2;
+        padding: 10px 16px;
+        border-radius: 30px;
+        font-weight: 600;
+        color: #333333;
+    }
+    .politeia-modal-messages {
+        background: #fff4e5;
+        border: 1px solid #ff9800;
+        padding: 16px;
+        border-radius: 10px;
+        margin-top: 20px;
+    }
+    .politeia-modal-messages p {
+        margin: 0 0 8px;
+        color: #7a4b00;
+        font-weight: 600;
+    }
+    .politeia-modal-messages ul {
+        margin: 0;
+        padding-left: 20px;
+        color: #7a4b00;
+    }
 </style>
 
-<p style="font-size:10px;text-align:center;margin-bottom:10px;letter-spacing:10px;">CURSO</p>
-<h3 style="text-align:center;margin-top:0;"><?php echo esc_html( $course_title ); ?></h3>
+<div class="politeia-modal-results">
+    <p style="font-size:10px;text-align:center;margin-bottom:10px;letter-spacing:10px;">CURSO</p>
+    <h3><?php echo esc_html( $course_title ); ?></h3>
 
-<!-- PRUEBA INICIAL -->
-<div class="quiz-results-container">
-  <div class="quiz-flex">
-    <div>
-      <div class="quiz-name">Prueba Inicial</div>
-      <div style="color:#666;">HOLA</div>
+    <div class="politeia-modal-grid">
+        <div class="politeia-modal-card">
+            <span><?php esc_html_e( 'Prueba Inicial', 'villegas-courses' ); ?></span>
+            <strong>
+                <?php
+                if ( is_numeric( $first_percentage ) ) {
+                    echo esc_html( $first_percentage ) . '%';
+                } else {
+                    echo '--';
+                }
+                ?>
+            </strong>
+            <div style="color:#5f6b75; font-size: 14px; font-weight: 500;">
+                <?php echo $first['formatted_date'] ? esc_html( $first['formatted_date'] ) : esc_html__( 'Sin fecha registrada', 'villegas-courses' ); ?>
+            </div>
+            <div style="color:#5f6b75; font-size: 13px; margin-top:6px;">
+                <?php
+                if ( isset( $first['score'] ) && $first['score'] > 0 ) {
+                    printf(
+                        /* translators: %d: quiz score */
+                        esc_html__( 'Puntaje: %d pts.', 'villegas-courses' ),
+                        intval( $first['score'] )
+                    );
+                } else {
+                    esc_html_e( 'Puntaje no disponible.', 'villegas-courses' );
+                }
+                ?>
+            </div>
+        </div>
+        <div class="politeia-modal-card">
+            <span><?php esc_html_e( 'Prueba Final', 'villegas-courses' ); ?></span>
+            <strong>
+                <?php
+                if ( is_numeric( $final_percentage ) ) {
+                    echo esc_html( $final_percentage ) . '%';
+                } else {
+                    echo '--';
+                }
+                ?>
+            </strong>
+            <div style="color:#5f6b75; font-size: 14px; font-weight: 500;">
+                <?php echo $final['formatted_date'] ? esc_html( $final['formatted_date'] ) : esc_html__( 'Sin fecha registrada', 'villegas-courses' ); ?>
+            </div>
+            <div style="color:#5f6b75; font-size: 13px; margin-top:6px;">
+                <?php
+                if ( isset( $final['score'] ) && $final['score'] > 0 ) {
+                    printf(
+                        /* translators: %d: quiz score */
+                        esc_html__( 'Puntaje: %d pts.', 'villegas-courses' ),
+                        intval( $final['score'] )
+                    );
+                } else {
+                    esc_html_e( 'Puntaje no disponible.', 'villegas-courses' );
+                }
+                ?>
+            </div>
+        </div>
     </div>
-    <div style="width:50%;background:#e9ecef;border-radius:15px;height:20px;overflow:hidden;">
-      <div style="width:<?php echo $first_data['pct']; ?>%;height:100%;background:#ff9800;"></div>
-    </div>
-    <div class="quiz-percentage"><?php echo $first_data['pct']; ?>%</div>
-  </div>
-</div>
 
-<!-- PRUEBA FINAL -->
-<div class="quiz-results-container">
-  <div class="quiz-flex">
-    <div>
-      <div class="quiz-name">Prueba Final</div>
-      <div style="color:#666;"><?php echo esc_html( $final_data['formatted_date'] ); ?></div>
-    </div>
-    <div style="width:50%;background:#e9ecef;border-radius:15px;height:20px;overflow:hidden;">
-      <div style="width:<?php echo $final_data['pct']; ?>%;height:100%;background:#ff9800;"></div>
-    </div>
-    <div class="quiz-percentage"><?php echo $final_data['pct']; ?>%</div>
-  </div>
-</div>
+    <?php if ( $show_comparison ) : ?>
+        <div class="politeia-modal-meta">
+            <?php if ( null !== $variation ) : ?>
+                <span class="politeia-modal-chip">
+                    <?php
+                    $sign = $variation > 0 ? '+' : '';
+                    printf(
+                        /* translators: %s: variation value */
+                        esc_html__( 'Variación: %s%d%%', 'villegas-courses' ),
+                        esc_html( $sign ),
+                        intval( $variation )
+                    );
+                    ?>
+                </span>
+            <?php endif; ?>
 
-<!-- BLOQUE EXTRA -->
-<div class="extra-stats-container" style="margin-bottom:0;">
-  <div class="quiz-flex">
-    <div style="flex:1;text-align:center;">
-      <div style="font-size:16px;color:#666;">Variación conocimientos</div>
-      <div style="font-size:36px;font-weight:bold;color:<?php echo $variation >= 0 ? '#9fd99f' : 'red'; ?>">
-        <?php echo abs( $variation ); ?>% <span><?php echo $variation >= 0 ? '▲' : '▼'; ?></span>
-      </div>
-    </div>
-    <div style="flex:1;text-align:center;">
-      <div style="font-size:16px;color:#666;">Completaste el curso en</div>
-      <div style="font-size:36px;font-weight:bold;"><?php echo $days_diff . ' ' . ( $days_diff === 1 ? 'día' : 'días' ); ?></div>
-    </div>
-  </div>
+            <?php if ( null !== $days_elapsed ) : ?>
+                <span class="politeia-modal-chip">
+                    <?php
+                    printf(
+                        /* translators: %d: number of days */
+                        esc_html__( 'Días entre intentos: %d', 'villegas-courses' ),
+                        intval( $days_elapsed )
+                    );
+                    ?>
+                </span>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+
+    <?php if ( ! empty( $messages ) ) : ?>
+        <div class="politeia-modal-messages">
+            <p><?php esc_html_e( 'Necesitas completar ambas pruebas para ver la comparación.', 'villegas-courses' ); ?></p>
+            <ul>
+                <?php foreach ( $messages as $message ) : ?>
+                    <li><?php echo esc_html( $message ); ?></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+    <?php endif; ?>
 </div>

--- a/templates/cursos-my-account.php
+++ b/templates/cursos-my-account.php
@@ -101,15 +101,36 @@ document.addEventListener('DOMContentLoaded', function() {
             fetch(ajax_object.ajaxurl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-                body: 'action=mostrar_resultados_curso&course_id=' + encodeURIComponent(cursoId)
+                body: new URLSearchParams({
+                    action: 'mostrar_resultados_curso',
+                    course_id: cursoId,
+                    nonce: ajax_object.resultsNonce || ''
+                })
             })
-            .then(response => response.text())
-            .then(html => {
+            .then(response => response.json())
+            .then(payload => {
+                const success = payload && payload.success;
+                const data = (payload && payload.data) ? payload.data : {};
+                const html = success && data.html ? data.html : '<p>No se pudieron cargar los resultados del curso.</p>';
+
                 modal.innerHTML = `
                     <button id="cerrar-resultados" style="position: absolute; top: 10px; right: 10px; background-color: #ccc; border: none; border-radius: 50%; width: 32px; height: 32px; font-weight: bold; font-size: 16px; cursor: pointer; line-height: 30px;">×</button>
                     ` + html;
                     modal.classList.add('visible');
                     overlay.classList.add('visible');
+
+                document.getElementById('cerrar-resultados')?.addEventListener('click', () => {
+                    modal.classList.remove('visible');
+                    overlay.classList.remove('visible');
+                });
+            })
+            .catch(() => {
+                modal.innerHTML = `
+                    <button id="cerrar-resultados" style="position: absolute; top: 10px; right: 10px; background-color: #ccc; border: none; border-radius: 50%; width: 32px; height: 32px; font-weight: bold; font-size: 16px; cursor: pointer; line-height: 30px;">×</button>
+                    <p>No se pudieron obtener los resultados en este momento. Inténtalo nuevamente más tarde.</p>
+                `;
+                modal.classList.add('visible');
+                overlay.classList.add('visible');
 
                 document.getElementById('cerrar-resultados')?.addEventListener('click', () => {
                     modal.classList.remove('visible');


### PR DESCRIPTION
## Summary
- update the overridden quiz result template to resolve first/final quizzes from PoliteiaCourse metadata, surface progress messaging, and refresh the comparison script
- refactor the modal results partial and AJAX handler to return structured JSON powered by _first/_final quiz IDs, including nonce validation and graceful fallbacks
- wire the account modal client to send the nonce, consume the JSON payload, and reuse the new comparison markup

## Testing
- php -l templates/show_quiz_result_box.php
- php -l partials/ajax-results-box.php
- php -l functions.php
- php -l my-ld-course-override.php
- php -l templates/cursos-my-account.php


------
https://chatgpt.com/codex/tasks/task_e_68dfc9dcdf508332a917174f0b13928a