### PR TITLE
Secure quiz AJAX endpoints and streamline polling

### DIFF
--- a/assets/custom-quiz-message.js
+++ b/assets/custom-quiz-message.js
@@ -25,9 +25,11 @@ document.addEventListener("DOMContentLoaded", function () {
 jQuery(document).on('learndash-quiz-finished', function () {
     if (typeof quizData !== 'undefined' && quizData.type === 'final') {
         var finalQuizNonce = quizData.finalQuizNonce || '';
+        var ajaxConfig = window.villegasAjax || {};
+        var ajaxUrl = ajaxConfig.ajaxUrl || '';
 
-        if (!finalQuizNonce) {
-            console.error('No se encontró nonce para el Final Quiz. Abortando envío.');
+        if (!finalQuizNonce || !ajaxUrl) {
+            console.error('Faltan datos para enviar el correo del Final Quiz. Abortando envío.');
             return;
         }
 
@@ -45,7 +47,7 @@ jQuery(document).on('learndash-quiz-finished', function () {
                 return;
             }
 
-            jQuery.post(ajax_object.ajaxurl, {
+            jQuery.post(ajaxUrl, {
                 action: 'enviar_correo_final_quiz',
                 quiz_id: quizData.quizId,
                 quiz_percentage: percentage,

--- a/assets/js/puntaje-privado.js
+++ b/assets/js/puntaje-privado.js
@@ -1,19 +1,28 @@
 document.addEventListener('DOMContentLoaded', function () {
     const checkbox = document.getElementById('puntaje_privado_checkbox');
-    if (!checkbox || typeof puntajePrivadoData === 'undefined') return;
+    if (!checkbox) return;
+
+    const ajaxConfig = window.villegasAjax || {};
+    const ajaxUrl = ajaxConfig.ajaxUrl || '';
+    const nonce = ajaxConfig.privacyNonce || '';
 
     checkbox.addEventListener('change', function () {
         const isPrivate = checkbox.checked;
-        const userId = puntajePrivadoData.userId;
+        const userId = parseInt(checkbox.dataset.userId || '0', 10);
+
+        if (!ajaxUrl || !nonce || !userId) {
+            console.error('No se pudo determinar la información necesaria para actualizar la privacidad del puntaje.');
+            return;
+        }
 
         console.log('Enviando AJAX:', {
             action: 'guardar_privacidad_puntaje',
             user_id: userId,
             puntaje_privado: isPrivate ? '1' : '0',
-            security: puntajePrivadoData.security
+            nonce: nonce
         });
 
-        fetch(puntajePrivadoData.ajaxurl, {
+        fetch(ajaxUrl, {
             method: 'POST',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -21,7 +30,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 action: 'guardar_privacidad_puntaje',
                 user_id: userId,
                 puntaje_privado: isPrivate ? '1' : '0',
-                security: puntajePrivadoData.security
+                nonce: nonce
             })
         })
         .then(res => res.json())

--- a/functions.php
+++ b/functions.php
@@ -126,19 +126,22 @@ function villegas_show_resultados_button($course_id, $user_id) {
     }
 }
 
-add_action(
-    'wp_enqueue_scripts',
-    function() {
-        wp_localize_script(
-            'custom-quiz-message',
-            'ajax_object',
-            [
-                'ajaxurl'      => admin_url( 'admin-ajax.php' ),
-                'resultsNonce' => wp_create_nonce( 'mostrar_resultados_curso' ),
-            ]
-        );
-    }
-);
+add_action( 'wp_enqueue_scripts', 'villegas_enqueue_ajax_globals' );
+
+function villegas_enqueue_ajax_globals() {
+    wp_register_script( 'villegas-ajax-globals', '', [], false, true );
+    wp_enqueue_script( 'villegas-ajax-globals' );
+
+    $ajax_data = [
+        'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+        'activityNonce'=> wp_create_nonce( 'politeia_quiz_activity' ),
+        'resultsNonce' => wp_create_nonce( 'mostrar_resultados_curso' ),
+        'privacyNonce' => wp_create_nonce( 'guardar_privacidad_puntaje' ),
+        'retryAfter'   => 5,
+    ];
+
+    wp_localize_script( 'villegas-ajax-globals', 'villegasAjax', $ajax_data );
+}
 
 /* INYECTAR EVALUACON CATEGORIAS A QUIZ (PRimera o Final) */
 
@@ -172,9 +175,9 @@ function villegas_inyectar_quiz_data_footer() {
         quizId: <?php echo json_encode($quiz_id); ?>
     });
 
-    // Fallback para ajax_object si no ha sido definido en otro lugar
-    window.ajax_object = window.ajax_object || {
-        ajaxurl: '<?php echo admin_url('admin-ajax.php'); ?>'
+    // Fallback para villegasAjax si no ha sido definido en otro lugar
+    window.villegasAjax = window.villegasAjax || {
+        ajaxUrl: '<?php echo admin_url('admin-ajax.php'); ?>'
     };
 </script>
 

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -3,68 +3,171 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
-    require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-quiz-stats.php';
-}
-
 if ( ! class_exists( 'PoliteiaCourse' ) ) {
     require_once plugin_dir_path( __FILE__ ) . '../classes/class-politeia-course.php';
 }
 
 function politeia_get_latest_quiz_activity() {
-    check_ajax_referer( 'politeia_quiz_activity', 'nonce' );
-
-    if ( ! is_user_logged_in() ) {
-        wp_send_json_error( 'No autorizado' );
+    if ( ! check_ajax_referer( 'politeia_quiz_activity', 'nonce', false ) ) {
+        wp_send_json_error( [ 'message' => esc_html__( 'Solicitud no válida.', 'villegas-courses' ) ], 403 );
     }
 
-    $quiz_id = isset( $_POST['quiz_id'] ) ? intval( $_POST['quiz_id'] ) : 0;
-    $user_id = isset( $_POST['user_id'] ) ? intval( $_POST['user_id'] ) : 0;
-    $current = get_current_user_id();
+    if ( ! is_user_logged_in() || ! current_user_can( 'read' ) ) {
+        wp_send_json_error( [ 'message' => esc_html__( 'No autorizado.', 'villegas-courses' ) ], 403 );
+    }
+
+    $quiz_id       = isset( $_POST['quiz_id'] ) ? absint( $_POST['quiz_id'] ) : 0;
+    $requested_user = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
+    $current_user  = get_current_user_id();
 
     if ( ! $quiz_id ) {
-        wp_send_json_error( 'Faltan datos' );
+        wp_send_json_error( [ 'message' => esc_html__( 'Faltan datos del cuestionario.', 'villegas-courses' ) ], 400 );
     }
 
-    if ( $user_id && $user_id !== $current ) {
-        wp_send_json_error( 'Usuario no autorizado' );
+    if ( $requested_user && $requested_user !== $current_user ) {
+        wp_send_json_error( [ 'message' => esc_html__( 'Usuario no autorizado.', 'villegas-courses' ) ], 403 );
     }
 
-    $user_id = $user_id ?: $current;
+    $user_id = $requested_user ? $requested_user : $current_user;
 
-    $stats    = new Politeia_Quiz_Stats( $quiz_id, $user_id );
-    $summary  = $stats->get_quiz_summary( $quiz_id );
-    $response = [
-        'percentage'        => $summary['percentage'],
-        'percentage_rounded'=> $summary['percentage_rounded'],
-        'score'             => $summary['score'],
-        'timestamp'         => $summary['timestamp'],
-        'formatted_date'    => $summary['formatted_date'],
-        'course_id'         => $stats->get_course_id(),
-        'is_first_quiz'     => $stats->is_first_quiz(),
-        'is_final_quiz'     => $stats->is_final_quiz(),
-    ];
+    $cache_key = sprintf( 'villegas_quiz_activity_%d_%d', $user_id, $quiz_id );
+    $cached    = get_transient( $cache_key );
 
-    if ( $stats->is_final_quiz() ) {
-        $first_summary = $stats->get_first_quiz_summary();
-        $final_summary = $stats->get_final_quiz_summary();
-
-        $response['first_percentage'] = $first_summary['percentage_rounded'];
-        $response['final_percentage'] = $final_summary['percentage_rounded'];
+    if ( false !== $cached ) {
+        wp_send_json_success( $cached );
     }
+
+    $summary = politeia_extract_quiz_attempt_summary( $user_id, $quiz_id );
+
+    $retry_seconds = politeia_get_quiz_poll_retry_interval();
 
     if ( ! $summary['has_attempt'] ) {
-        wp_send_json_error( [ 'message' => 'Sin intentos' ] );
+        $pending = [
+            'status'      => 'pending',
+            'retry_after' => $retry_seconds,
+        ];
+
+        set_transient( $cache_key, $pending, $retry_seconds );
+
+        wp_send_json_success( $pending );
     }
+
+    $course_id = 0;
+    $is_first  = false;
+    $is_final  = false;
+    $first_quiz = 0;
+    $final_quiz = 0;
+
+    if ( class_exists( 'PoliteiaCourse' ) ) {
+        $course_id = PoliteiaCourse::getCourseFromQuiz( $quiz_id );
+        if ( $course_id ) {
+            $first_quiz = intval( PoliteiaCourse::getFirstQuizId( $course_id ) );
+            $final_quiz = intval( PoliteiaCourse::getFinalQuizId( $course_id ) );
+
+            $is_first = $first_quiz && $first_quiz === $quiz_id;
+            $is_final = $final_quiz && $final_quiz === $quiz_id;
+        }
+    }
+
+    $response = [
+        'status'             => 'ready',
+        'percentage'         => is_null( $summary['percentage'] ) ? null : (float) $summary['percentage'],
+        'percentage_rounded' => is_null( $summary['percentage'] ) ? null : intval( round( $summary['percentage'] ) ),
+        'score'              => intval( $summary['score'] ),
+        'timestamp'          => intval( $summary['timestamp'] ),
+        'formatted_date'     => $summary['formatted_date'],
+        'course_id'          => $course_id ? intval( $course_id ) : 0,
+        'is_first_quiz'      => (bool) $is_first,
+        'is_final_quiz'      => (bool) $is_final,
+    ];
+
+    if ( $is_final && $first_quiz ) {
+        $first_summary = politeia_extract_quiz_attempt_summary( $user_id, $first_quiz );
+
+        $response['first_percentage'] = is_null( $first_summary['percentage'] )
+            ? null
+            : intval( round( $first_summary['percentage'] ) );
+        $response['final_percentage'] = is_null( $summary['percentage'] )
+            ? null
+            : intval( round( $summary['percentage'] ) );
+    }
+
+    $cache_ttl = apply_filters( 'villegas_quiz_activity_cache_ttl', 15, $quiz_id, $user_id );
+    set_transient( $cache_key, $response, max( 1, intval( $cache_ttl ) ) );
 
     wp_send_json_success( $response );
 }
 add_action( 'wp_ajax_get_latest_quiz_activity', 'politeia_get_latest_quiz_activity' );
-add_action( 'wp_ajax_nopriv_get_latest_quiz_activity', 'politeia_get_latest_quiz_activity' );
 
 // Backwards compatibility: keep previous hook name but delegate to the new handler.
 function get_latest_quiz_score() {
     politeia_get_latest_quiz_activity();
 }
 add_action( 'wp_ajax_get_latest_quiz_score', 'get_latest_quiz_score' );
-add_action( 'wp_ajax_nopriv_get_latest_quiz_score', 'get_latest_quiz_score' );
+
+function politeia_extract_quiz_attempt_summary( $user_id, $quiz_id ) {
+    $user_id = intval( $user_id );
+    $quiz_id = intval( $quiz_id );
+
+    $empty = [
+        'has_attempt'    => false,
+        'percentage'     => null,
+        'score'          => 0,
+        'timestamp'      => 0,
+        'formatted_date' => '',
+    ];
+
+    if ( ! $user_id || ! $quiz_id ) {
+        return $empty;
+    }
+
+    static $user_attempts = [];
+
+    if ( ! isset( $user_attempts[ $user_id ] ) ) {
+        $raw_attempts = get_user_meta( $user_id, '_sfwd-quizzes', true );
+        $attempts     = maybe_unserialize( $raw_attempts );
+        $user_attempts[ $user_id ] = is_array( $attempts ) ? $attempts : [];
+    }
+
+    $latest_attempt = null;
+
+    foreach ( $user_attempts[ $user_id ] as $attempt ) {
+        if ( ! is_array( $attempt ) || ! isset( $attempt['quiz'] ) ) {
+            continue;
+        }
+
+        if ( intval( $attempt['quiz'] ) !== $quiz_id ) {
+            continue;
+        }
+
+        $attempt_time = isset( $attempt['time'] ) ? intval( $attempt['time'] ) : 0;
+
+        if ( null === $latest_attempt || $attempt_time > intval( $latest_attempt['time'] ?? 0 ) ) {
+            $latest_attempt = $attempt;
+        }
+    }
+
+    if ( null === $latest_attempt ) {
+        return $empty;
+    }
+
+    $percentage = isset( $latest_attempt['percentage'] ) && is_numeric( $latest_attempt['percentage'] )
+        ? floatval( $latest_attempt['percentage'] )
+        : null;
+
+    $timestamp = isset( $latest_attempt['time'] ) ? intval( $latest_attempt['time'] ) : 0;
+
+    return [
+        'has_attempt'    => $timestamp > 0,
+        'percentage'     => $percentage,
+        'score'          => isset( $latest_attempt['score'] ) ? intval( $latest_attempt['score'] ) : 0,
+        'timestamp'      => $timestamp,
+        'formatted_date' => $timestamp ? esc_html( date_i18n( 'j \d\e F \d\e Y', $timestamp ) ) : '',
+    ];
+}
+
+function politeia_get_quiz_poll_retry_interval() {
+    $default = 5;
+
+    return max( 1, intval( apply_filters( 'villegas_quiz_activity_retry_after', $default ) ) );
+}

--- a/templates/cursos-my-account.php
+++ b/templates/cursos-my-account.php
@@ -97,14 +97,22 @@ document.addEventListener('DOMContentLoaded', function() {
         if (e.target.classList.contains('ver-resultados-btn')) {
             e.preventDefault();
             const cursoId = e.target.dataset.courseId;
+            const ajaxConfig = window.villegasAjax || {};
+            const ajaxUrl = ajaxConfig.ajaxUrl || '';
+            const nonce = ajaxConfig.resultsNonce || '';
 
-            fetch(ajax_object.ajaxurl, {
+            if (!ajaxUrl || !nonce) {
+                console.error('No hay configuración AJAX disponible para cargar los resultados.');
+                return;
+            }
+
+            fetch(ajaxUrl, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: new URLSearchParams({
                     action: 'mostrar_resultados_curso',
                     course_id: cursoId,
-                    nonce: ajax_object.resultsNonce || ''
+                    nonce: nonce
                 })
             })
             .then(response => response.json())


### PR DESCRIPTION
## Summary
- provide a global `villegasAjax` config with nonce values and fallbacks for all quiz/result scripts
- harden `get_latest_quiz_activity` with capability checks, transient caching, and pending responses instead of tight polling
- secure course results and score privacy handlers with capability/nonce validation and sanitized payloads while updating frontend scripts to use the new AJAX config

## Testing
- php -l functions.php
- php -l includes/ajax-handlers.php
- php -l my-ld-course-override.php
- php -l templates/cursos-my-account.php
- php -l templates/show_quiz_result_box.php

------
https://chatgpt.com/codex/tasks/task_e_68dfd02a4d0c83329bc2444e542312c3