### PR TITLE
Hook quiz completion emails

### DIFF
--- a/includes/class-villegas-quiz-email-handler.php
+++ b/includes/class-villegas-quiz-email-handler.php
@@ -1,0 +1,41 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Villegas_Quiz_Email_Handler {
+
+    /**
+     * Called when a quiz is completed in LearnDash.
+     *
+     * @param array  $quiz_data Payload provided by LearnDash.
+     * @param object $user      WP_User object for the user who completed the quiz.
+     */
+    public static function on_quiz_completed( $quiz_data, $user ) {
+
+        // Use our helper to collect debug data
+        $debug = Villegas_Quiz_Emails::get_quiz_debug_data( $quiz_data, $user );
+
+        // Bail if not First or Final quiz
+        if ( empty( $debug['is_first_quiz'] ) && empty( $debug['is_final_quiz'] ) ) {
+            return;
+        }
+
+        // Choose which template to load
+        if ( $debug['is_first_quiz'] ) {
+            require_once plugin_dir_path( __FILE__ ) . '../emails/first-quiz-email.php';
+            $email_content = villegas_get_first_quiz_email_content( $quiz_data, $user, $debug );
+        } elseif ( $debug['is_final_quiz'] ) {
+            require_once plugin_dir_path( __FILE__ ) . '../emails/final-quiz-email.php';
+            $email_content = villegas_get_final_quiz_email_content( $quiz_data, $user, $debug );
+        }
+
+        // Send the email
+        if ( ! empty( $email_content['subject'] ) && ! empty( $email_content['body'] ) ) {
+            $to      = get_option( 'admin_email' ); // For now, send to admin. Can extend later.
+            $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+
+            wp_mail( $to, $email_content['subject'], $email_content['body'], $headers );
+        }
+    }
+}

--- a/my-ld-course-override.php
+++ b/my-ld-course-override.php
@@ -18,6 +18,11 @@ if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
     require_once plugin_dir_path( __FILE__ ) . 'classes/class-politeia-quiz-stats.php';
 }
 
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-emails.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-email-handler.php';
+
+add_action( 'learndash_quiz_completed', [ 'Villegas_Quiz_Email_Handler', 'on_quiz_completed' ], 10, 2 );
+
 // Reemplazar la plantilla del curso de LearnDash
 function my_custom_ld_course_template( $template ) {
     if ( is_singular( 'sfwd-courses' ) ) {


### PR DESCRIPTION
## Summary
- add a LearnDash quiz completion handler to trigger Villegas email logic
- wire the handler into the plugin bootstrap and require the helper classes

## Testing
- php -l includes/class-villegas-quiz-email-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e02a37076083328bb7960d7a8ec631