### PR TITLE
Connect quiz email handler to templates and add logging

### DIFF
--- a/includes/class-villegas-quiz-email-handler.php
+++ b/includes/class-villegas-quiz-email-handler.php
@@ -21,6 +21,8 @@ class Villegas_Quiz_Email_Handler {
             return;
         }
 
+        $email_content = null;
+
         // Choose which template to load
         if ( $debug['is_first_quiz'] ) {
             require_once plugin_dir_path( __FILE__ ) . '../emails/first-quiz-email.php';
@@ -31,11 +33,18 @@ class Villegas_Quiz_Email_Handler {
         }
 
         // Send the email
-        if ( ! empty( $email_content['subject'] ) && ! empty( $email_content['body'] ) ) {
+        if ( is_array( $email_content ) && ! empty( $email_content['subject'] ) && ! empty( $email_content['body'] ) ) {
             $to      = get_option( 'admin_email' ); // For now, send to admin. Can extend later.
             $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
 
-            wp_mail( $to, $email_content['subject'], $email_content['body'], $headers );
+            $sent = wp_mail( $to, $email_content['subject'], $email_content['body'], $headers );
+
+            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( '[Villegas Quiz Emails] Email sent? ' . ( $sent ? 'YES' : 'NO' ) );
+                error_log( '[Villegas Quiz Emails] Recipient: ' . $to );
+                error_log( '[Villegas Quiz Emails] Subject: ' . $email_content['subject'] );
+                error_log( '[Villegas Quiz Emails] Debug Data: ' . print_r( $debug, true ) );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Load the appropriate first or final quiz email template once a quiz completion event fires
- Send the assembled email to the admin and log debug information when WP_DEBUG is enabled

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e02b7674dc83329efeb87fad1c62ca