### PR TITLE
Add quiz email settings page

### DIFF
--- a/includes/class-villegas-quiz-email-handler.php
+++ b/includes/class-villegas-quiz-email-handler.php
@@ -35,20 +35,28 @@ class Villegas_Quiz_Email_Handler {
         // Send the email
         if ( is_array( $email_content ) && ! empty( $email_content['subject'] ) && ! empty( $email_content['body'] ) ) {
             // Decide recipients
-            $default_recipients = [ $user->user_email ];
-            $admin_email        = get_option( 'admin_email' );
+            $send_to_student = get_option( 'villegas_quiz_email_send_to_student', 1 );
+            $send_to_admin   = apply_filters( 'villegas_quiz_email_include_admin', get_option( 'villegas_quiz_email_send_to_admin', 1 ), $debug );
+            $custom_prefix   = get_option( 'villegas_quiz_email_custom_subject', '' );
 
-            // Optionally include admin in CC
-            $include_admin = apply_filters( 'villegas_quiz_email_include_admin', true, $debug );
-            if ( $include_admin && $admin_email ) {
-                $default_recipients[] = $admin_email;
+            $recipients = [];
+
+            if ( $send_to_student && ! empty( $user->user_email ) ) {
+                $recipients[] = $user->user_email;
+            }
+
+            if ( $send_to_admin ) {
+                $admin_email = get_option( 'admin_email' );
+                if ( $admin_email ) {
+                    $recipients[] = $admin_email;
+                }
             }
 
             // Allow full customization of recipients
-            $recipients = apply_filters( 'villegas_quiz_email_recipients', $default_recipients, $debug );
+            $recipients = apply_filters( 'villegas_quiz_email_recipients', $recipients, $debug );
 
             // Subject and body can also be filtered
-            $subject = apply_filters( 'villegas_quiz_email_subject', $email_content['subject'], $debug );
+            $subject = apply_filters( 'villegas_quiz_email_subject', ( $custom_prefix ? $custom_prefix . ' ' : '' ) . $email_content['subject'], $debug );
             $body    = apply_filters( 'villegas_quiz_email_body', $email_content['body'], $debug );
 
             $headers = [ 'Content-Type: text/html; charset=UTF-8' ];

--- a/includes/class-villegas-quiz-email-settings.php
+++ b/includes/class-villegas-quiz-email-settings.php
@@ -1,0 +1,72 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Villegas_Quiz_Email_Settings {
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu_page' ] );
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
+    }
+
+    public static function add_menu_page() {
+        add_options_page(
+            __( 'Quiz Email Settings', 'villegas-courses' ),
+            __( 'Quiz Emails', 'villegas-courses' ),
+            'manage_options',
+            'villegas-quiz-emails',
+            [ __CLASS__, 'render_settings_page' ]
+        );
+    }
+
+    public static function register_settings() {
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_send_to_student' );
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_send_to_admin' );
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_custom_subject' );
+    }
+
+    public static function render_settings_page() {
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Quiz Email Settings', 'villegas-courses' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php settings_fields( 'villegas_quiz_email_group' ); ?>
+                <?php do_settings_sections( 'villegas_quiz_email_group' ); ?>
+
+                <table class="form-table">
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Send to Student', 'villegas-courses' ); ?></th>
+                        <td>
+                            <input type="checkbox" name="villegas_quiz_email_send_to_student" value="1" 
+                                <?php checked( 1, get_option( 'villegas_quiz_email_send_to_student', 1 ) ); ?> />
+                            <label><?php esc_html_e( 'Send quiz results to the student who took the quiz', 'villegas-courses' ); ?></label>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Send to Admin', 'villegas-courses' ); ?></th>
+                        <td>
+                            <input type="checkbox" name="villegas_quiz_email_send_to_admin" value="1" 
+                                <?php checked( 1, get_option( 'villegas_quiz_email_send_to_admin', 1 ) ); ?> />
+                            <label><?php esc_html_e( 'Send quiz results to the site admin email', 'villegas-courses' ); ?></label>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Custom Subject Prefix', 'villegas-courses' ); ?></th>
+                        <td>
+                            <input type="text" name="villegas_quiz_email_custom_subject" 
+                                value="<?php echo esc_attr( get_option( 'villegas_quiz_email_custom_subject', '' ) ); ?>" 
+                                class="regular-text" />
+                            <p class="description"><?php esc_html_e( 'Optional prefix to add before the email subject', 'villegas-courses' ); ?></p>
+                        </td>
+                    </tr>
+                </table>
+
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+}

--- a/my-ld-course-override.php
+++ b/my-ld-course-override.php
@@ -21,6 +21,11 @@ if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-emails.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-email-handler.php';
 
+if ( is_admin() ) {
+    require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-email-settings.php';
+    Villegas_Quiz_Email_Settings::init();
+}
+
 add_action( 'learndash_quiz_completed', [ 'Villegas_Quiz_Email_Handler', 'on_quiz_completed' ], 10, 2 );
 
 // Reemplazar la plantilla del curso de LearnDash


### PR DESCRIPTION
## Summary
- add an admin settings page to manage quiz email recipients and subject prefix
- bootstrap the new settings screen when the plugin loads in the admin
- update the quiz email handler to honor the saved options when choosing recipients and subjects

## Testing
- php -l includes/class-villegas-quiz-email-settings.php
- php -l includes/class-villegas-quiz-email-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e02c659ccc8332b548deb18b5d7a94