### PR TITLE
Add cron-based queue for quiz email retries

### DIFF
--- a/includes/class-villegas-quiz-email-handler.php
+++ b/includes/class-villegas-quiz-email-handler.php
@@ -21,9 +21,84 @@ class Villegas_Quiz_Email_Handler {
             return;
         }
 
+        if ( 'None' === $debug['first_quiz_attempt'] && 'None' === $debug['final_quiz_attempt'] ) {
+            $queue = get_option( 'villegas_quiz_email_queue', [] );
+
+            if ( ! is_array( $queue ) ) {
+                $queue = [];
+            }
+
+            $queue[] = [
+                'user_id'   => $debug['user_id'],
+                'quiz_id'   => $debug['quiz_id'],
+                'course_id' => $debug['course_id_detected'],
+                'created'   => time(),
+                'retries'   => 0,
+            ];
+
+            update_option( 'villegas_quiz_email_queue', $queue, false );
+
+            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( '[Villegas Quiz Emails] Queued quiz attempt for later retry: ' . $debug['quiz_id'] );
+            }
+
+            return;
+        }
+
+        self::send_email( $quiz_data, $user, $debug );
+    }
+
+    public static function process_queue() {
+        $queue = get_option( 'villegas_quiz_email_queue', [] );
+
+        if ( ! is_array( $queue ) ) {
+            $queue = [];
+        }
+
+        if ( empty( $queue ) ) {
+            return;
+        }
+
+        $new_queue = [];
+
+        foreach ( $queue as $entry ) {
+            $user = get_user_by( 'id', $entry['user_id'] );
+
+            if ( ! $user ) {
+                continue;
+            }
+
+            $quiz_data = [
+                'quiz'   => $entry['quiz_id'],
+                'course' => $entry['course_id'],
+            ];
+
+            $debug = Villegas_Quiz_Emails::get_quiz_debug_data( $quiz_data, $user );
+
+            if ( 'None' !== $debug['first_quiz_attempt'] || 'None' !== $debug['final_quiz_attempt'] ) {
+                self::send_email( $quiz_data, $user, $debug );
+                continue;
+            }
+
+            $entry['retries']++;
+
+            if ( $entry['retries'] < 3 ) {
+                $new_queue[] = $entry;
+
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                    error_log( '[Villegas Quiz Emails] Requeueing attempt #' . $entry['retries'] . ' for quiz: ' . $entry['quiz_id'] );
+                }
+            } elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( '[Villegas Quiz Emails] Dropping attempt after 3 retries: ' . $entry['quiz_id'] );
+            }
+        }
+
+        update_option( 'villegas_quiz_email_queue', $new_queue, false );
+    }
+
+    private static function send_email( $quiz_data, $user, $debug ) {
         $email_content = null;
 
-        // Choose which template to load
         if ( $debug['is_first_quiz'] ) {
             require_once plugin_dir_path( __FILE__ ) . '../emails/first-quiz-email.php';
             $email_content = villegas_get_first_quiz_email_content( $quiz_data, $user, $debug );
@@ -32,43 +107,44 @@ class Villegas_Quiz_Email_Handler {
             $email_content = villegas_get_final_quiz_email_content( $quiz_data, $user, $debug );
         }
 
-        // Send the email
-        if ( is_array( $email_content ) && ! empty( $email_content['subject'] ) && ! empty( $email_content['body'] ) ) {
-            // Decide recipients
-            $send_to_student = get_option( 'villegas_quiz_email_send_to_student', 1 );
-            $send_to_admin   = apply_filters( 'villegas_quiz_email_include_admin', get_option( 'villegas_quiz_email_send_to_admin', 1 ), $debug );
-            $custom_prefix   = get_option( 'villegas_quiz_email_custom_subject', '' );
+        if ( ! is_array( $email_content ) || empty( $email_content['subject'] ) || empty( $email_content['body'] ) ) {
+            return;
+        }
 
-            $recipients = [];
+        $send_to_student = get_option( 'villegas_quiz_email_send_to_student', 1 );
+        $send_to_admin   = apply_filters( 'villegas_quiz_email_include_admin', get_option( 'villegas_quiz_email_send_to_admin', 1 ), $debug );
+        $custom_prefix   = get_option( 'villegas_quiz_email_custom_subject', '' );
 
-            if ( $send_to_student && ! empty( $user->user_email ) ) {
-                $recipients[] = $user->user_email;
+        $recipients = [];
+
+        if ( $send_to_student && ! empty( $user->user_email ) ) {
+            $recipients[] = $user->user_email;
+        }
+
+        if ( $send_to_admin ) {
+            $admin_email = get_option( 'admin_email' );
+
+            if ( $admin_email ) {
+                $recipients[] = $admin_email;
             }
+        }
 
-            if ( $send_to_admin ) {
-                $admin_email = get_option( 'admin_email' );
-                if ( $admin_email ) {
-                    $recipients[] = $admin_email;
-                }
-            }
+        $recipients = apply_filters( 'villegas_quiz_email_recipients', $recipients, $debug );
 
-            // Allow full customization of recipients
-            $recipients = apply_filters( 'villegas_quiz_email_recipients', $recipients, $debug );
+        $subject = apply_filters( 'villegas_quiz_email_subject', ( $custom_prefix ? $custom_prefix . ' ' : '' ) . $email_content['subject'], $debug );
+        $body    = apply_filters( 'villegas_quiz_email_body', $email_content['body'], $debug );
 
-            // Subject and body can also be filtered
-            $subject = apply_filters( 'villegas_quiz_email_subject', ( $custom_prefix ? $custom_prefix . ' ' : '' ) . $email_content['subject'], $debug );
-            $body    = apply_filters( 'villegas_quiz_email_body', $email_content['body'], $debug );
+        $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
 
-            $headers = [ 'Content-Type: text/html; charset=UTF-8' ];
+        $sent = wp_mail( $recipients, $subject, $body, $headers );
 
-            $sent = wp_mail( $recipients, $subject, $body, $headers );
-
-            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                error_log( '[Villegas Quiz Emails] Sent? ' . ( $sent ? 'YES' : 'NO' ) );
-                error_log( '[Villegas Quiz Emails] Recipients: ' . implode( ',', (array) $recipients ) );
-                error_log( '[Villegas Quiz Emails] Subject: ' . $subject );
-                error_log( '[Villegas Quiz Emails] Debug Data: ' . print_r( $debug, true ) );
-            }
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( '[Villegas Quiz Emails] Sent? ' . ( $sent ? 'YES' : 'NO' ) );
+            error_log( '[Villegas Quiz Emails] Recipients: ' . implode( ',', (array) $recipients ) );
+            error_log( '[Villegas Quiz Emails] Subject: ' . $subject );
+            error_log( '[Villegas Quiz Emails] Debug Data: ' . print_r( $debug, true ) );
         }
     }
 }
+
+add_action( 'villegas_process_quiz_email_queue', [ 'Villegas_Quiz_Email_Handler', 'process_queue' ] );

--- a/my-ld-course-override.php
+++ b/my-ld-course-override.php
@@ -21,6 +21,27 @@ if ( ! class_exists( 'Politeia_Quiz_Stats' ) ) {
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-emails.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-email-handler.php';
 
+register_activation_hook( __FILE__, function() {
+    if ( ! wp_next_scheduled( 'villegas_process_quiz_email_queue' ) ) {
+        wp_schedule_event( time() + 300, 'five_minutes', 'villegas_process_quiz_email_queue' );
+    }
+} );
+
+register_deactivation_hook( __FILE__, function() {
+    wp_clear_scheduled_hook( 'villegas_process_quiz_email_queue' );
+} );
+
+add_filter( 'cron_schedules', function( $schedules ) {
+    if ( ! isset( $schedules['five_minutes'] ) ) {
+        $schedules['five_minutes'] = [
+            'interval' => 300,
+            'display'  => __( 'Every Five Minutes', 'villegas-courses' ),
+        ];
+    }
+
+    return $schedules;
+} );
+
 if ( is_admin() ) {
     require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-quiz-email-settings.php';
     Villegas_Quiz_Email_Settings::init();


### PR DESCRIPTION
## Summary
- add WP-Cron scheduling for processing pending quiz email attempts every five minutes
- queue quiz completion notifications when LearnDash results are not yet persisted and retry up to three times
- centralize quiz email delivery logic for reuse between immediate sends and cron retries with helpful debug logging

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e02d9bdba88332ab25838d696b2f75