### PR TITLE
Add customizable quiz email templates

### DIFF
--- a/includes/class-villegas-quiz-email-settings.php
+++ b/includes/class-villegas-quiz-email-settings.php
@@ -24,6 +24,10 @@ class Villegas_Quiz_Email_Settings {
         register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_send_to_student' );
         register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_send_to_admin' );
         register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_custom_subject' );
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_first_subject' );
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_first_body' );
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_final_subject' );
+        register_setting( 'villegas_quiz_email_group', 'villegas_quiz_email_final_body' );
     }
 
     public static function render_settings_page() {
@@ -56,10 +60,54 @@ class Villegas_Quiz_Email_Settings {
                     <tr>
                         <th scope="row"><?php esc_html_e( 'Custom Subject Prefix', 'villegas-courses' ); ?></th>
                         <td>
-                            <input type="text" name="villegas_quiz_email_custom_subject" 
-                                value="<?php echo esc_attr( get_option( 'villegas_quiz_email_custom_subject', '' ) ); ?>" 
+                            <input type="text" name="villegas_quiz_email_custom_subject"
+                                value="<?php echo esc_attr( get_option( 'villegas_quiz_email_custom_subject', '' ) ); ?>"
                                 class="regular-text" />
                             <p class="description"><?php esc_html_e( 'Optional prefix to add before the email subject', 'villegas-courses' ); ?></p>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'First Quiz Email – Subject', 'villegas-courses' ); ?></th>
+                        <td>
+                            <input type="text" name="villegas_quiz_email_first_subject"
+                                   value="<?php echo esc_attr( get_option( 'villegas_quiz_email_first_subject', 'Your First Quiz Results: {quiz_title}' ) ); ?>"
+                                   class="regular-text" />
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'First Quiz Email – Body', 'villegas-courses' ); ?></th>
+                        <td>
+                            <textarea name="villegas_quiz_email_first_body" rows="6" cols="60"><?php
+                                echo esc_textarea( get_option(
+                                    'villegas_quiz_email_first_body',
+                                    "Hello {user_name},\n\nYou scored {first_score} in {quiz_title} for {course_title}.\nDate: {quiz_date}"
+                                ) );
+                            ?></textarea>
+                            <p class="description"><?php esc_html_e( 'Use placeholders like {user_name}, {quiz_title}, {course_title}, {first_score}, {quiz_date}', 'villegas-courses' ); ?></p>
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Final Quiz Email – Subject', 'villegas-courses' ); ?></th>
+                        <td>
+                            <input type="text" name="villegas_quiz_email_final_subject"
+                                   value="<?php echo esc_attr( get_option( 'villegas_quiz_email_final_subject', 'Your Final Quiz Results: {quiz_title}' ) ); ?>"
+                                   class="regular-text" />
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <th scope="row"><?php esc_html_e( 'Final Quiz Email – Body', 'villegas-courses' ); ?></th>
+                        <td>
+                            <textarea name="villegas_quiz_email_final_body" rows="6" cols="60"><?php
+                                echo esc_textarea( get_option(
+                                    'villegas_quiz_email_final_body',
+                                    "Hello {user_name},\n\nYou scored {final_score} in {quiz_title}.\nYour First Quiz was {first_score}, so your progress is {progress_delta}%.\nDate: {quiz_date}"
+                                ) );
+                            ?></textarea>
+                            <p class="description"><?php esc_html_e( 'Use placeholders like {user_name}, {quiz_title}, {course_title}, {first_score}, {final_score}, {progress_delta}, {quiz_date}', 'villegas-courses' ); ?></p>
                         </td>
                     </tr>
                 </table>

--- a/includes/class-villegas-quiz-emails.php
+++ b/includes/class-villegas-quiz-emails.php
@@ -125,4 +125,18 @@ class Villegas_Quiz_Emails {
             'ld_percentage_hook' => $quiz_data['percentage'],
         ];
     }
+
+    public static function replace_placeholders( $template, $debug ) {
+        $replacements = [
+            '{user_name}'      => isset( $debug['user_display_name'] ) ? esc_html( $debug['user_display_name'] ) : '',
+            '{quiz_title}'     => isset( $debug['quiz_title'] ) ? esc_html( $debug['quiz_title'] ) : '',
+            '{course_title}'   => isset( $debug['course_title'] ) ? esc_html( $debug['course_title'] ) : '',
+            '{first_score}'    => isset( $debug['first_quiz_attempt'] ) ? esc_html( $debug['first_quiz_attempt'] ) : '',
+            '{final_score}'    => isset( $debug['final_quiz_attempt'] ) ? esc_html( $debug['final_quiz_attempt'] ) : '',
+            '{progress_delta}' => isset( $debug['progress_delta'] ) ? esc_html( $debug['progress_delta'] ) . '%' : '',
+            '{quiz_date}'      => esc_html( date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) ) ),
+        ];
+
+        return strtr( $template, $replacements );
+    }
 }


### PR DESCRIPTION
## Summary
- add admin options to configure first and final quiz email subjects and bodies
- implement placeholder replacement helper for quiz emails and apply it to outgoing messages
- update email handler to use customizable templates and compute progress delta for final quiz notifications

## Testing
- php -l includes/class-villegas-quiz-email-settings.php
- php -l includes/class-villegas-quiz-emails.php
- php -l includes/class-villegas-quiz-email-handler.php

------
https://chatgpt.com/codex/tasks/task_e_68e02f4a276c833289cccf2706c216d5