### PR TITLE
Ensure latest quiz result endpoint returns completed attempt

### DIFF
--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -211,8 +211,7 @@ function villegas_get_latest_quiz_result() {
         ], 403 );
     }
 
-    $quiz_id          = isset( $_POST['quiz_id'] ) ? absint( $_POST['quiz_id'] ) : 0;
-    $last_activity_id = isset( $_POST['last_activity_id'] ) ? absint( $_POST['last_activity_id'] ) : 0;
+    $quiz_id = isset( $_POST['quiz_id'] ) ? absint( $_POST['quiz_id'] ) : 0;
 
     if ( ! $quiz_id ) {
         wp_send_json_error( [
@@ -223,59 +222,116 @@ function villegas_get_latest_quiz_result() {
 
     global $wpdb;
 
-    $activity_id = $wpdb->get_var(
+    $user_id = get_current_user_id();
+
+    $latest_attempt = $wpdb->get_row(
         $wpdb->prepare(
-            "SELECT activity_id
-             FROM {$wpdb->prefix}learndash_user_activity
-             WHERE user_id = %d AND post_id = %d AND activity_type = 'quiz'
-             ORDER BY activity_completed DESC
+            "SELECT ua.activity_id, ua.activity_completed
+             FROM {$wpdb->prefix}learndash_user_activity AS ua
+             INNER JOIN {$wpdb->prefix}learndash_user_activity_meta AS uam
+                ON ua.activity_id = uam.activity_id
+             WHERE ua.user_id = %d
+               AND ua.activity_type = 'quiz'
+               AND uam.activity_meta_key = 'quiz'
+               AND uam.activity_meta_value+0 = %d
+               AND ua.activity_completed IS NOT NULL
+             ORDER BY ua.activity_id DESC
              LIMIT 1",
-            get_current_user_id(),
+            $user_id,
             $quiz_id
-        )
+        ),
+        ARRAY_A
     );
+
+    if ( empty( $latest_attempt ) ) {
+        wp_send_json(
+            [
+                'success' => true,
+                'status'  => 'pending',
+                'message' => esc_html__( 'Todavía no registramos tu intento.', 'villegas-courses' ),
+            ]
+        );
+    }
+
+    $activity_id        = isset( $latest_attempt['activity_id'] ) ? absint( $latest_attempt['activity_id'] ) : 0;
+    $activity_completed = isset( $latest_attempt['activity_completed'] ) ? intval( $latest_attempt['activity_completed'] ) : 0;
 
     if ( ! $activity_id ) {
-        wp_send_json_error( [
-            'message' => esc_html__( 'Todavía no registramos tu intento.', 'villegas-courses' ),
-            'code'    => 'not_ready',
-        ] );
+        wp_send_json(
+            [
+                'success' => true,
+                'status'  => 'pending',
+                'message' => esc_html__( 'Todavía no registramos tu intento.', 'villegas-courses' ),
+            ]
+        );
     }
 
-    $activity_id = absint( $activity_id );
-
-    if ( $last_activity_id && $activity_id <= $last_activity_id ) {
-        wp_send_json_error( [
-            'message' => esc_html__( 'Esperando nuevo intento.', 'villegas-courses' ),
-            'code'    => 'not_ready',
-        ] );
-    }
-
-    $percentage_raw = $wpdb->get_var(
+    $meta_rows = $wpdb->get_results(
         $wpdb->prepare(
-            "SELECT activity_meta_value
+            "SELECT activity_meta_key, activity_meta_value
              FROM {$wpdb->prefix}learndash_user_activity_meta
-             WHERE activity_id = %d AND activity_meta_key = 'percentage'
-             LIMIT 1",
+             WHERE activity_id = %d",
             $activity_id
-        )
+        ),
+        ARRAY_A
     );
 
-    if ( null === $percentage_raw || '' === $percentage_raw || ! is_numeric( $percentage_raw ) ) {
-        wp_send_json_error( [
-            'message' => esc_html__( 'El porcentaje aún no está disponible.', 'villegas-courses' ),
-            'code'    => 'not_ready',
-        ] );
+    $meta = [];
+
+    foreach ( (array) $meta_rows as $row ) {
+        if ( empty( $row['activity_meta_key'] ) ) {
+            continue;
+        }
+
+        $meta_key   = sanitize_key( $row['activity_meta_key'] );
+        $meta_value = isset( $row['activity_meta_value'] ) ? $row['activity_meta_value'] : '';
+
+        $meta[ $meta_key ] = $meta_value;
     }
 
-    $percentage = intval( round( floatval( $percentage_raw ) ) );
+    $percentage_value = null;
 
-    wp_send_json_success(
-        [
-            'percentage'  => $percentage,
-            'activity_id' => $activity_id,
-        ]
-    );
+    if ( isset( $meta['percentage'] ) && '' !== $meta['percentage'] && is_numeric( $meta['percentage'] ) ) {
+        $percentage_value = round( floatval( $meta['percentage'] ), 2 );
+    }
+
+    if ( null === $percentage_value ) {
+        wp_send_json(
+            [
+                'success'      => true,
+                'status'       => 'pending',
+                'activity_id'  => $activity_id,
+                'timestamp'    => $activity_completed,
+                'message'      => esc_html__( 'El porcentaje aún no está disponible.', 'villegas-courses' ),
+            ]
+        );
+    }
+
+    $score_value = null;
+
+    if ( isset( $meta['score'] ) && is_numeric( $meta['score'] ) ) {
+        $score_value = 0 + $meta['score'];
+    }
+
+    $total_points_value = null;
+
+    if ( isset( $meta['total_points'] ) && is_numeric( $meta['total_points'] ) ) {
+        $total_points_value = 0 + $meta['total_points'];
+    }
+
+    $response = [
+        'success'            => true,
+        'status'             => 'ready',
+        'percentage'         => $percentage_value,
+        'score'              => $score_value,
+        'total_points'       => $total_points_value,
+        'timestamp'          => $activity_completed,
+        'formatted_date'     => $activity_completed ? esc_html( date_i18n( 'j \d\e F \d\e Y', $activity_completed ) ) : '',
+        'activity_id'        => $activity_id,
+        'percentage_rounded' => intval( round( $percentage_value ) ),
+    ];
+
+    wp_send_json( $response );
 }
 add_action( 'wp_ajax_villegas_get_latest_quiz_result', 'villegas_get_latest_quiz_result' );
 add_action( 'wp_ajax_nopriv_villegas_get_latest_quiz_result', 'villegas_get_latest_quiz_result' );


### PR DESCRIPTION
## Summary
- update `villegas_get_latest_quiz_result` to mirror the quiz activity lookup used by politeia and fetch the latest completed attempt via the activity/meta tables
- include quiz score, total points, percentage, completion timestamp, and formatted date in the JSON response while signalling pending status only when no completed attempt exists

## Testing
- php -l includes/ajax-handlers.php

------
https://chatgpt.com/codex/tasks/task_e_68e032a7b47083328b7455375ada79f5