### PR TITLE
Handle pending LearnDash quiz metadata before updating results

### DIFF
--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -19,8 +19,6 @@ function politeia_get_latest_quiz_activity() {
     $quiz_id        = isset( $_POST['quiz_id'] ) ? absint( $_POST['quiz_id'] ) : 0;
     $requested_user = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
     $current_user   = get_current_user_id();
-    $last_timestamp = isset( $_POST['last_timestamp'] ) ? intval( $_POST['last_timestamp'] ) : 0;
-    $awaiting_attempt = ! empty( $_POST['awaiting_attempt'] );
 
     if ( ! $quiz_id ) {
         wp_send_json_error( [ 'message' => esc_html__( 'Faltan datos del cuestionario.', 'villegas-courses' ) ], 400 );
@@ -32,95 +30,127 @@ function politeia_get_latest_quiz_activity() {
 
     $user_id = $requested_user ? $requested_user : $current_user;
 
-    $cache_key = sprintf( 'villegas_quiz_activity_%d_%d', $user_id, $quiz_id );
-    $cached    = get_transient( $cache_key );
+    global $wpdb;
 
-    if ( $awaiting_attempt ) {
-        $cached = false;
+    $activity = $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT activity_id, activity_completed
+             FROM {$wpdb->prefix}learndash_user_activity
+             WHERE user_id = %d
+               AND post_id = %d
+               AND activity_type = 'quiz'
+             ORDER BY activity_id DESC
+             LIMIT 1",
+            $user_id,
+            $quiz_id
+        ),
+        ARRAY_A
+    );
+
+    $default_retry_after = politeia_get_quiz_poll_retry_interval();
+
+    if ( empty( $activity ) || empty( $activity['activity_id'] ) ) {
+        wp_send_json_success(
+            [
+                'status'      => 'pending',
+                'activity_id' => 0,
+                'retry_after' => $default_retry_after,
+                'message'     => esc_html__( 'Todavía no registramos tu intento.', 'villegas-courses' ),
+            ]
+        );
     }
 
-    if ( false !== $cached ) {
-        $cached_timestamp = isset( $cached['timestamp'] ) ? intval( $cached['timestamp'] ) : 0;
+    $activity_id        = intval( $activity['activity_id'] );
+    $activity_timestamp = isset( $activity['activity_completed'] ) ? intval( $activity['activity_completed'] ) : 0;
 
-        if ( $last_timestamp && $cached_timestamp && $cached_timestamp <= $last_timestamp ) {
-            $cached = false;
-        }
-    }
+    $meta = politeia_fetch_activity_meta_map( $activity_id );
 
-    if ( false !== $cached ) {
-        wp_send_json_success( $cached );
-    }
+    $quiz_meta_value = isset( $meta['quiz'] ) ? intval( $meta['quiz'] ) : 0;
+    $has_quiz_meta   = $quiz_meta_value === $quiz_id;
+    $percentage_raw  = isset( $meta['percentage'] ) ? $meta['percentage'] : null;
+    $has_percentage  = ( '' !== $percentage_raw && null !== $percentage_raw && is_numeric( $percentage_raw ) );
 
-    $summary = politeia_extract_quiz_attempt_summary( $user_id, $quiz_id );
+    if ( ! $has_quiz_meta || ! $has_percentage ) {
+        $pending_retry_after = max(
+            1,
+            intval( apply_filters( 'villegas_quiz_activity_pending_retry_after', 2, $quiz_id, $user_id, $activity_id ) )
+        );
 
-    $retry_seconds = politeia_get_quiz_poll_retry_interval();
-
-    if ( ! $summary['has_attempt'] ) {
-        $pending = [
+        $pending_payload = [
             'status'      => 'pending',
-            'retry_after' => $retry_seconds,
+            'activity_id' => $activity_id,
+            'retry_after' => $pending_retry_after,
+            'message'     => esc_html__( 'Quiz meta pending...', 'villegas-courses' ),
         ];
 
-        set_transient( $cache_key, $pending, $retry_seconds );
-
-        wp_send_json_success( $pending );
+        wp_send_json_success( $pending_payload );
     }
 
-    $course_id = 0;
-    $is_first  = false;
-    $is_final  = false;
-    $first_quiz = 0;
-    $final_quiz = 0;
+    $percentage         = round( floatval( $percentage_raw ), 2 );
+    $percentage_rounded = intval( round( $percentage ) );
+    $score              = ( isset( $meta['score'] ) && is_numeric( $meta['score'] ) ) ? 0 + $meta['score'] : null;
+    $total_points       = ( isset( $meta['total_points'] ) && is_numeric( $meta['total_points'] ) ) ? 0 + $meta['total_points'] : null;
 
-    if ( class_exists( 'PoliteiaCourse' ) ) {
-        $course_id = PoliteiaCourse::getCourseFromQuiz( $quiz_id );
-        if ( $course_id ) {
-            $first_quiz = intval( PoliteiaCourse::getFirstQuizId( $course_id ) );
-            $final_quiz = intval( PoliteiaCourse::getFinalQuizId( $course_id ) );
-
-            $is_first = $first_quiz && $first_quiz === $quiz_id;
-            $is_final = $final_quiz && $final_quiz === $quiz_id;
-        }
+    if ( ! $activity_timestamp ) {
+        $activity_timestamp = current_time( 'timestamp' );
     }
 
     $response = [
         'status'             => 'ready',
-        'percentage'         => is_null( $summary['percentage'] ) ? null : (float) $summary['percentage'],
-        'percentage_rounded' => is_null( $summary['percentage'] ) ? null : intval( round( $summary['percentage'] ) ),
-        'score'              => is_null( $summary['score'] ) ? null : intval( $summary['score'] ),
-        'total_points'       => is_null( $summary['total_points'] ) ? null : ( 0 + $summary['total_points'] ),
-        'timestamp'          => intval( $summary['timestamp'] ),
-        'formatted_date'     => $summary['formatted_date'],
-        'activity_id'        => isset( $summary['activity_id'] ) ? intval( $summary['activity_id'] ) : 0,
-        'course_id'          => $course_id ? intval( $course_id ) : 0,
-        'is_first_quiz'      => (bool) $is_first,
-        'is_final_quiz'      => (bool) $is_final,
+        'activity_id'        => $activity_id,
+        'percentage'         => $percentage,
+        'percentage_rounded' => $percentage_rounded,
+        'score'              => $score,
+        'total_points'       => $total_points,
+        'timestamp'          => $activity_timestamp,
+        'formatted_date'     => politeia_format_quiz_activity_date( $activity_timestamp ),
     ];
 
-    if ( $is_final && $first_quiz ) {
-        $first_summary = politeia_extract_quiz_attempt_summary( $user_id, $first_quiz );
+    $course_id      = 0;
+    $first_quiz_id  = 0;
+    $final_quiz_id  = 0;
+    $is_first_quiz  = false;
+    $is_final_quiz  = false;
 
-        $response['first_percentage'] = is_null( $first_summary['percentage'] )
-            ? null
-            : intval( round( $first_summary['percentage'] ) );
-        $response['final_percentage'] = is_null( $summary['percentage'] )
-            ? null
-            : intval( round( $summary['percentage'] ) );
+    if ( class_exists( 'PoliteiaCourse' ) ) {
+        $course_id = intval( PoliteiaCourse::getCourseFromQuiz( $quiz_id ) );
 
-        if ( ! is_null( $response['first_percentage'] ) && ! is_null( $response['final_percentage'] ) ) {
-            $response['progress_delta'] = intval( $response['final_percentage'] - $response['first_percentage'] );
-        }
+        if ( $course_id ) {
+            $first_quiz_id = intval( PoliteiaCourse::getFirstQuizId( $course_id ) );
+            $final_quiz_id = intval( PoliteiaCourse::getFinalQuizId( $course_id ) );
 
-        if ( $first_summary['timestamp'] && $summary['timestamp'] && $summary['timestamp'] >= $first_summary['timestamp'] ) {
-            $response['days_elapsed'] = max(
-                1,
-                floor( ( intval( $summary['timestamp'] ) - intval( $first_summary['timestamp'] ) ) / DAY_IN_SECONDS )
-            );
+            $is_first_quiz = $first_quiz_id && $first_quiz_id === $quiz_id;
+            $is_final_quiz = $final_quiz_id && $final_quiz_id === $quiz_id;
+
+            if ( $is_final_quiz && $first_quiz_id ) {
+                $first_summary = politeia_get_quiz_attempt_summary_for_comparison( $user_id, $first_quiz_id );
+
+                $response['first_percentage'] = null;
+                $response['final_percentage'] = $percentage_rounded;
+                $response['progress_delta']   = null;
+                $response['days_elapsed']     = null;
+
+                if ( $first_summary ) {
+                    $first_percentage = intval( round( $first_summary['percentage'] ) );
+
+                    $response['first_percentage'] = $first_percentage;
+                    $response['progress_delta']   = $percentage_rounded - $first_percentage;
+
+                    if ( ! empty( $first_summary['timestamp'] ) && $activity_timestamp ) {
+                        $delta_seconds            = max( 0, intval( $activity_timestamp ) - intval( $first_summary['timestamp'] ) );
+                        $response['days_elapsed'] = intval( floor( $delta_seconds / DAY_IN_SECONDS ) );
+                    }
+                }
+            }
         }
     }
 
-    $cache_ttl = apply_filters( 'villegas_quiz_activity_cache_ttl', 15, $quiz_id, $user_id );
-    set_transient( $cache_key, $response, max( 1, intval( $cache_ttl ) ) );
+    if ( $course_id ) {
+        $response['course_id'] = $course_id;
+    }
+
+    $response['is_first_quiz'] = $is_first_quiz;
+    $response['is_final_quiz'] = $is_final_quiz;
 
     wp_send_json_success( $response );
 }
@@ -232,6 +262,140 @@ function politeia_get_quiz_poll_retry_interval() {
     $default = 5;
 
     return max( 1, intval( apply_filters( 'villegas_quiz_activity_retry_after', $default ) ) );
+}
+
+/**
+ * Retrieve and normalize all metadata for a given LearnDash activity ID.
+ *
+ * @param int $activity_id Activity identifier.
+ *
+ * @return array
+ */
+function politeia_fetch_activity_meta_map( $activity_id ) {
+    $activity_id = intval( $activity_id );
+
+    if ( ! $activity_id ) {
+        return [];
+    }
+
+    global $wpdb;
+
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT activity_meta_key, activity_meta_value
+             FROM {$wpdb->prefix}learndash_user_activity_meta
+             WHERE activity_id = %d",
+            $activity_id
+        ),
+        ARRAY_A
+    );
+
+    $meta = [];
+
+    foreach ( (array) $rows as $row ) {
+        if ( empty( $row['activity_meta_key'] ) ) {
+            continue;
+        }
+
+        $key = sanitize_key( $row['activity_meta_key'] );
+
+        if ( '' === $key ) {
+            continue;
+        }
+
+        $meta[ $key ] = isset( $row['activity_meta_value'] ) ? $row['activity_meta_value'] : '';
+    }
+
+    return $meta;
+}
+
+/**
+ * Format the timestamp associated with a quiz attempt using the site locale.
+ *
+ * @param int $timestamp Unix timestamp.
+ *
+ * @return string
+ */
+function politeia_format_quiz_activity_date( $timestamp ) {
+    $timestamp = intval( $timestamp );
+
+    if ( $timestamp <= 0 ) {
+        return '';
+    }
+
+    return date_i18n( 'j \d\e F \d\e Y H:i', $timestamp );
+}
+
+/**
+ * Fetch the latest completed attempt summary for comparison charts.
+ *
+ * @param int $user_id User identifier.
+ * @param int $quiz_id Quiz identifier.
+ *
+ * @return array|null
+ */
+function politeia_get_quiz_attempt_summary_for_comparison( $user_id, $quiz_id ) {
+    $user_id = intval( $user_id );
+    $quiz_id = intval( $quiz_id );
+
+    if ( ! $user_id || ! $quiz_id ) {
+        return null;
+    }
+
+    global $wpdb;
+
+    $limit = max( 1, intval( apply_filters( 'villegas_quiz_activity_comparison_attempt_limit', 10, $quiz_id, $user_id ) ) );
+
+    $attempts = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT activity_id, activity_completed
+             FROM {$wpdb->prefix}learndash_user_activity
+             WHERE user_id = %d
+               AND post_id = %d
+               AND activity_type = 'quiz'
+             ORDER BY activity_id DESC
+             LIMIT %d",
+            $user_id,
+            $quiz_id,
+            $limit
+        ),
+        ARRAY_A
+    );
+
+    foreach ( (array) $attempts as $attempt ) {
+        if ( empty( $attempt['activity_id'] ) ) {
+            continue;
+        }
+
+        $activity_id = intval( $attempt['activity_id'] );
+        $meta        = politeia_fetch_activity_meta_map( $activity_id );
+
+        $quiz_meta_value = isset( $meta['quiz'] ) ? intval( $meta['quiz'] ) : 0;
+
+        if ( $quiz_meta_value && $quiz_meta_value !== $quiz_id ) {
+            continue;
+        }
+
+        if ( ! isset( $meta['percentage'] ) || '' === $meta['percentage'] || ! is_numeric( $meta['percentage'] ) ) {
+            continue;
+        }
+
+        $percentage = round( floatval( $meta['percentage'] ), 2 );
+        $score      = ( isset( $meta['score'] ) && is_numeric( $meta['score'] ) ) ? 0 + $meta['score'] : null;
+        $total      = ( isset( $meta['total_points'] ) && is_numeric( $meta['total_points'] ) ) ? 0 + $meta['total_points'] : null;
+        $timestamp  = isset( $attempt['activity_completed'] ) ? intval( $attempt['activity_completed'] ) : 0;
+
+        return [
+            'activity_id'    => $activity_id,
+            'percentage'     => $percentage,
+            'score'          => $score,
+            'total_points'   => $total,
+            'timestamp'      => $timestamp,
+            'formatted_date' => politeia_format_quiz_activity_date( $timestamp ),
+        ];
+    }
+
+    return null;
 }
 
 function villegas_get_latest_quiz_result() {

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -461,8 +461,10 @@ $show_loading_notice = ! $current_summary['has_attempt'];
 
     const ajaxUrl = ajaxConfig.ajaxUrl || '';
     const defaultRetry = parseInt(ajaxConfig.retryAfter, 10) > 0 ? parseInt(ajaxConfig.retryAfter, 10) : 5;
+    const maxPollRetries = 30;
 
     const loadingNoticeEl = document.getElementById('politeia-loading-notice');
+    const loadingNoticeDefaultText = loadingNoticeEl ? loadingNoticeEl.textContent : '';
 
     let chartInstance = null;
     const attemptBox = $('#politeia-quiz-attempt');
@@ -477,6 +479,10 @@ $show_loading_notice = ! $current_summary['has_attempt'];
             return;
         }
 
+        if (loadingNoticeEl) {
+            loadingNoticeEl.textContent = loadingNoticeDefaultText;
+        }
+
         restoreLastAttempt();
         setAwaitingState(false);
     }
@@ -486,6 +492,9 @@ $show_loading_notice = ! $current_summary['has_attempt'];
 
         if (quizConfig.awaitingAttempt) {
             if (loadingNoticeEl) {
+                if (loadingNoticeDefaultText) {
+                    loadingNoticeEl.textContent = loadingNoticeDefaultText;
+                }
                 loadingNoticeEl.style.display = '';
             }
 
@@ -506,6 +515,7 @@ $show_loading_notice = ! $current_summary['has_attempt'];
             }
 
             if (loadingNoticeEl) {
+                loadingNoticeEl.textContent = loadingNoticeDefaultText;
                 loadingNoticeEl.style.display = 'none';
             }
         }
@@ -552,6 +562,7 @@ $show_loading_notice = ! $current_summary['has_attempt'];
         }
 
         if (loadingNoticeEl) {
+            loadingNoticeEl.textContent = loadingNoticeDefaultText;
             loadingNoticeEl.style.display = 'none';
         }
 
@@ -667,19 +678,15 @@ $show_loading_notice = ! $current_summary['has_attempt'];
     }
 
     function queueRetry(retriesLeft, waitSeconds) {
-        const attemptsRemaining = typeof retriesLeft === 'number' ? retriesLeft : 0;
-        const shouldContinue = quizConfig.awaitingAttempt || attemptsRemaining > 0;
+        const remaining = typeof retriesLeft === 'number' ? retriesLeft : 0;
 
-        if (!shouldContinue) {
+        if (remaining <= 0) {
             return;
         }
 
-        const nextRetries = quizConfig.awaitingAttempt
-            ? attemptsRemaining
-            : Math.max(0, attemptsRemaining - 1);
         const delaySeconds = parseInt(waitSeconds, 10) > 0 ? parseInt(waitSeconds, 10) : defaultRetry;
 
-        setTimeout(function(){ pollLatestAttempt(nextRetries); }, delaySeconds * 1000);
+        setTimeout(function(){ pollLatestAttempt(remaining); }, delaySeconds * 1000);
     }
 
     function pollLatestAttempt(retries) {
@@ -687,7 +694,12 @@ $show_loading_notice = ! $current_summary['has_attempt'];
             return;
         }
 
-        const retriesLeft = typeof retries === 'number' ? retries : 0;
+        const retriesLeft = typeof retries === 'number' ? retries : maxPollRetries;
+
+        if (retriesLeft <= 0) {
+            return;
+        }
+
         const lastTimestamp = parseInt(quizConfig.currentAttemptTimestamp, 10) || 0;
 
         const requestData = {
@@ -698,20 +710,51 @@ $show_loading_notice = ! $current_summary['has_attempt'];
             last_timestamp: lastTimestamp
         };
 
-        if (quizConfig.awaitingAttempt) {
-            requestData.awaiting_attempt = '1';
-            if (loadingNoticeEl) {
-                loadingNoticeEl.style.display = '';
-            }
+        if (quizConfig.awaitingAttempt && loadingNoticeEl) {
+            loadingNoticeEl.style.display = '';
         }
 
         $.post(ajaxUrl, requestData).done(function(response){
             if (response && response.success) {
                 const payload = response.data || {};
                 const waitSeconds = parseInt(payload.retry_after, 10) > 0 ? parseInt(payload.retry_after, 10) : defaultRetry;
+                const attemptIdentifier = (typeof payload.activity_id !== 'undefined' && payload.activity_id !== null && payload.activity_id !== '')
+                    ? payload.activity_id
+                    : '—';
+                let logPercentage = '—';
+
+                if (typeof payload.percentage !== 'undefined' && payload.percentage !== null && payload.percentage !== '') {
+                    logPercentage = payload.percentage;
+                } else if (typeof payload.percentage_rounded !== 'undefined' && payload.percentage_rounded !== null && payload.percentage_rounded !== '') {
+                    logPercentage = payload.percentage_rounded;
+                }
+
+                const logStatus = payload.status || 'unknown';
+                console.log(`[Quiz Poll] Attempt ${attemptIdentifier} | Status: ${logStatus} | Percentage: ${logPercentage !== '' ? logPercentage : '—'} | Next retry: ${waitSeconds}s`);
 
                 if (payload.status === 'pending') {
-                    queueRetry(retriesLeft, waitSeconds);
+                    const pendingActivityId = parseInt(payload.activity_id, 10);
+
+                    if (!quizConfig.awaitingAttempt) {
+                        setAwaitingState(true);
+                    }
+
+                    if (loadingNoticeEl) {
+                        if (!isNaN(pendingActivityId) && pendingActivityId > 0) {
+                            loadingNoticeEl.textContent = `Processing attempt ID: ${pendingActivityId}…`;
+                        } else {
+                            loadingNoticeEl.textContent = loadingNoticeDefaultText || 'Processing attempt…';
+                        }
+                        loadingNoticeEl.style.display = '';
+                    }
+
+                    if (!isNaN(pendingActivityId) && pendingActivityId > 0) {
+                        quizConfig.currentActivityId = pendingActivityId;
+                        $('[data-activity-id-target]').text(pendingActivityId);
+                        $('#quiz-activity-id').text(pendingActivityId);
+                    }
+
+                    queueRetry(retriesLeft - 1, waitSeconds);
                     return;
                 }
 
@@ -739,11 +782,13 @@ $show_loading_notice = ! $current_summary['has_attempt'];
                 updateAttemptUI(attemptData);
 
                 return;
-            }
+            console.log(`[Quiz Poll] Attempt — | Status: error_response | Percentage: — | Next retry: ${defaultRetry}s`);
 
-            queueRetry(retriesLeft, defaultRetry);
+            queueRetry(retriesLeft - 1, defaultRetry);
         }).fail(function(){
-            queueRetry(retriesLeft, defaultRetry);
+            console.log(`[Quiz Poll] Attempt — | Status: ajax_error | Percentage: — | Next retry: ${defaultRetry}s`);
+
+            queueRetry(retriesLeft - 1, defaultRetry);
         });
     }
 
@@ -769,19 +814,19 @@ $show_loading_notice = ! $current_summary['has_attempt'];
                 timestamp: <?php echo intval( $current_summary['timestamp'] ); ?>
             });
         } else {
-            pollLatestAttempt(6);
+            pollLatestAttempt(maxPollRetries);
         }
 
         if (quizConfig.awaitingAttempt) {
             quizConfig.hideResultsWhilePending = true;
             setAwaitingState(true);
-            pollLatestAttempt(6);
+            pollLatestAttempt(maxPollRetries);
         }
     });
 
     $(document).on('learndash-quiz-finished', function(){
         setAwaitingState(true);
-        pollLatestAttempt(6);
+        pollLatestAttempt(maxPollRetries);
     });
 
     $(document).on('click', '.wpProQuiz_sending .wpProQuiz_button_cancel, .wpProQuiz_button_cancel', function(){


### PR DESCRIPTION
## Summary
- query the newest LearnDash quiz activity by activity_id, validate required metadata, and surface pending status until the attempt is complete
- add reusable helpers for fetching activity meta, formatting dates, and computing comparison data for final quizzes
- enhance the quiz result polling UI to show pending attempt IDs, retry up to 30 times with console logging, and refresh the display once metadata arrives

## Testing
- php -l includes/ajax-handlers.php
- php -l templates/show_quiz_result_box.php

------
https://chatgpt.com/codex/tasks/task_e_68e0411a92308332b3b426ee9bb0ca30