### PR TITLE
Ensure latest quiz activity is surfaced while metadata is pending

### DIFF
--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -50,6 +50,8 @@ function politeia_get_latest_quiz_activity() {
     $default_retry_after = politeia_get_quiz_poll_retry_interval();
 
     if ( empty( $activity ) || empty( $activity['activity_id'] ) ) {
+        error_log( sprintf( '[AJAX] User %d, Quiz %d, Activity %d, Status: pending', $user_id, $quiz_id, 0 ) );
+
         wp_send_json_success(
             [
                 'status'      => 'pending',
@@ -83,6 +85,8 @@ function politeia_get_latest_quiz_activity() {
             'message'     => esc_html__( 'Quiz meta pending...', 'villegas-courses' ),
         ];
 
+        error_log( sprintf( '[AJAX] User %d, Quiz %d, Activity %d, Status: pending', $user_id, $quiz_id, $activity_id ) );
+
         wp_send_json_success( $pending_payload );
     }
 
@@ -105,6 +109,8 @@ function politeia_get_latest_quiz_activity() {
         'timestamp'          => $activity_timestamp,
         'formatted_date'     => politeia_format_quiz_activity_date( $activity_timestamp ),
     ];
+
+    error_log( sprintf( '[AJAX] User %d, Quiz %d, Activity %d, Status: ready, Percentage %s', $user_id, $quiz_id, $activity_id, $percentage ) );
 
     $course_id      = 0;
     $first_quiz_id  = 0;

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -43,11 +43,10 @@ $current_summary = wp_parse_args(
     ]
 );
 
-$current_percentage_value = ( isset( $current_summary['percentage_rounded'] ) && is_numeric( $current_summary['percentage_rounded'] ) )
-    ? intval( $current_summary['percentage_rounded'] )
-    : null;
-
 $latest_activity_id = 0;
+
+$latest_activity_meta    = [];
+$latest_activity_pending = false;
 
 if ( $user_id && $quiz_id ) {
     $latest_activity_id = intval(
@@ -56,14 +55,38 @@ if ( $user_id && $quiz_id ) {
                 "SELECT activity_id
                  FROM {$wpdb->prefix}learndash_user_activity
                  WHERE user_id = %d AND post_id = %d AND activity_type = 'quiz'
-                 ORDER BY activity_completed DESC
+                 ORDER BY activity_id DESC
                  LIMIT 1",
                 $user_id,
                 $quiz_id
             )
         )
     );
+
+    if ( $latest_activity_id ) {
+        $latest_activity_meta      = politeia_fetch_activity_meta_map( $latest_activity_id );
+        $latest_activity_quiz_id   = isset( $latest_activity_meta['quiz'] ) ? intval( $latest_activity_meta['quiz'] ) : 0;
+        $latest_activity_perc_raw  = isset( $latest_activity_meta['percentage'] ) ? $latest_activity_meta['percentage'] : null;
+        $latest_activity_has_perc  = ( '' !== $latest_activity_perc_raw && null !== $latest_activity_perc_raw && is_numeric( $latest_activity_perc_raw ) );
+
+        if ( $latest_activity_quiz_id !== $quiz_id || ! $latest_activity_has_perc ) {
+            $latest_activity_pending = true;
+
+            $current_summary['has_attempt']        = false;
+            $current_summary['timestamp']          = 0;
+            $current_summary['formatted_date']     = '';
+            $current_summary['score']              = null;
+            $current_summary['percentage']         = null;
+            $current_summary['percentage_rounded'] = null;
+
+            error_log( sprintf( '[QuizTemplate] User %d, Quiz %d, Activity %d, Pending state triggered', $user_id, $quiz_id, $latest_activity_id ) );
+        }
+    }
 }
+
+$current_percentage_value = ( isset( $current_summary['percentage_rounded'] ) && is_numeric( $current_summary['percentage_rounded'] ) )
+    ? intval( $current_summary['percentage_rounded'] )
+    : null;
 
 $has_first_quiz = (bool) $first_quiz_id;
 $has_final_quiz = (bool) $final_quiz_id;
@@ -114,6 +137,11 @@ if ( $is_final_quiz ) {
     $cta_url  = $course_url ? $course_url : home_url();
 }
 $show_loading_notice = ! $current_summary['has_attempt'];
+
+if ( $latest_activity_pending ) {
+    $show_loading_notice      = true;
+    $current_percentage_value = null;
+}
 ?>
 <style>
 .politeia-quiz-results {


### PR DESCRIPTION
## Summary
- query LearnDash quiz attempts by activity_id and mark attempts pending when metadata is incomplete in QuizAnalytics
- update the quiz results template to detect pending attempts, trigger polling immediately, and emit debug logs
- add debug logging to the AJAX handler for both pending and ready attempt responses

## Testing
- php -l classes/class-quiz-analytics.php
- php -l templates/show_quiz_result_box.php
- php -l includes/ajax-handlers.php

------
https://chatgpt.com/codex/tasks/task_e_68e04a155dd483328f9d75df682f1a15