### PR TITLE
Hide quiz debug meta table

### DIFF
--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -46,6 +46,7 @@ array(
 </div>
 
 <div style="display: none;" class="wpProQuiz_results">
+<hr>
 <h4 style="font-family: sans-serif; font-size: 34px;" class="wpProQuiz_header"><?php esc_html_e( 'Results', 'learndash' ); ?></h4>
 <?php
 if ( ! $quiz->isHideResultCorrectQuestion() ) {

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -46,7 +46,7 @@ array(
 </div>
 
 <div style="display: none;" class="wpProQuiz_results">
-<h4 class="wpProQuiz_header"><?php esc_html_e( 'Results', 'learndash' ); ?></h4>
+<h4 style="font-family: sans-serif; font-size: 34px;" class="wpProQuiz_header"><?php esc_html_e( 'Results', 'learndash' ); ?></h4>
 <?php
 if ( ! $quiz->isHideResultCorrectQuestion() ) {
 echo wp_kses_post(

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -213,7 +213,7 @@ if ( class_exists( 'CourseQuizMetaHelper' ) && $quiz_id ) {
     }
 }
 ?>
-<table class="wpProQuiz_pointsChart__meta debug_table" style="text-align: center; font-size: 14px;">
+<table class="wpProQuiz_pointsChart__meta debug_table" style="text-align: center; font-size: 14px; display: none;">
     <tbody>
         <tr>
             <th scope="row" style="padding-right: 8px; text-align: right;">


### PR DESCRIPTION
## Summary
- hide the wpProQuiz meta debug table by applying an inline display:none style

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4f150c658833293b35873be5ed059