### PR TITLE
Translate quiz score labels and add divider

### DIFF
--- a/shortcodes/quiz-average-score-shortcode.php
+++ b/shortcodes/quiz-average-score-shortcode.php
@@ -77,7 +77,7 @@ function villegas_quiz_average_score_shortcode( $atts ): string {
     <div<?php echo $attributes_markup; ?>>
         <svg class="wpProQuiz_pointsChart__svg" viewBox="0 0 36 36" role="img" style="width: 120px; height: 120px;">
             <circle class="wpProQuiz_pointsChart__track" cx="18" cy="18" r="16" fill="none" stroke="#E3E3E3" stroke-width="4"></circle>
-            <circle class="wpProQuiz_pointsChart__progress" cx="18" cy="18" r="16" fill="none" stroke="#2196F3" stroke-width="4" stroke-linecap="round" stroke-dasharray="0 100" stroke-dashoffset="25.12" transform="rotate(-90 18 18)"></circle>
+            <circle class="wpProQuiz_pointsChart__progress" cx="18" cy="18" r="16" fill="none" stroke="#f9c600" stroke-width="4" stroke-linecap="round" stroke-dasharray="0 100" stroke-dashoffset="25.12" transform="rotate(-90 18 18)"></circle>
         </svg>
         <div class="wpProQuiz_pointsChart__label" style="font-weight: 600;">
             <?php echo esc_html( $label ); ?>

--- a/shortcodes/quiz-average-score-shortcode.php
+++ b/shortcodes/quiz-average-score-shortcode.php
@@ -16,7 +16,7 @@ function villegas_quiz_average_score_shortcode( $atts ): string {
         [
             'quiz_id'  => 0,
             'decimals' => 0,
-            'title'    => __( 'Average Score', 'villegas-courses' ),
+            'title'    => __( 'Puntaje Promedio', 'villegas-courses' ),
         ],
         $atts,
         'villegas_quiz_average_score'
@@ -59,7 +59,7 @@ function villegas_quiz_average_score_shortcode( $atts ): string {
         'aria-live'       => 'polite',
         'data-chart-id'   => 'average-score',
         'data-chart-title'=> $title,
-        'style'           => 'display: inline-flex; flex-direction: column; align-items: center; gap: 8px; margin: 1em 0;',
+        'style'           => 'display: inline-flex; flex-direction: column; align-items: center; gap: 8px; margin: 1em 0 1em 1em;',
     ];
 
     if ( $has_data ) {

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -111,7 +111,7 @@ if ( ! $quiz->isHideResultPoints() ) {
     $average_chart_markup = '';
 
     if ( $quiz_id ) {
-        $average_chart_markup = do_shortcode( sprintf( '[villegas_quiz_average_score quiz_id="%d" title="%s"]', $quiz_id, esc_attr__( 'Average Score', 'villegas-courses' ) ) );
+        $average_chart_markup = do_shortcode( sprintf( '[villegas_quiz_average_score quiz_id="%d" title="%s"]', $quiz_id, esc_attr__( 'Puntaje Promedio', 'villegas-courses' ) ) );
     }
 ?>
 <p class="wpProQuiz_points wpProQuiz_points--message" style="display: none;">
@@ -130,16 +130,17 @@ array(
 );
 ?>
 </p>
-<div id="wpProQuiz_pointsChartUser" class="wpProQuiz_pointsChart" aria-live="polite" data-chart-id="user-score" data-chart-title="<?php esc_attr_e( 'User Score', 'villegas-courses' ); ?>" style="display: inline-flex; flex-direction: column; align-items: center; gap: 8px; margin: 1em 1em 1em 0;">
+<div id="wpProQuiz_pointsChartUser" class="wpProQuiz_pointsChart" aria-live="polite" data-chart-id="user-score" data-chart-title="<?php esc_attr_e( 'Tu Puntaje', 'villegas-courses' ); ?>" style="display: inline-flex; flex-direction: column; align-items: center; gap: 8px; margin: 1em 1em 1em 0;">
     <svg class="wpProQuiz_pointsChart__svg" viewBox="0 0 36 36" role="img" style="width: 120px; height: 120px;">
         <circle class="wpProQuiz_pointsChart__track" cx="18" cy="18" r="16" fill="none" stroke="#E3E3E3" stroke-width="4"></circle>
         <circle class="wpProQuiz_pointsChart__progress" cx="18" cy="18" r="16" fill="none" stroke="#4CAF50" stroke-width="4" stroke-linecap="round" stroke-dasharray="0 100" stroke-dashoffset="25.12" transform="rotate(-90 18 18)"></circle>
     </svg>
     <div class="wpProQuiz_pointsChart__label" style="font-weight: 600;"></div>
     <div class="wpProQuiz_pointsChart__caption" style="font-size: 14px;">
-        <?php esc_html_e( 'User Score', 'villegas-courses' ); ?>
+        <?php esc_html_e( 'Tu Puntaje', 'villegas-courses' ); ?>
     </div>
 </div>
+<div id="quiz-score-divider" style="display: inline-block; width: 1px; height: 140px; background-color: #E3E3E3; margin: 1em 0; vertical-align: middle;"></div>
 <?php if ( ! empty( $average_chart_markup ) ) : ?>
     <?php echo $average_chart_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 <?php endif; ?>

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -132,7 +132,7 @@ array(
 </p>
 <div id="wpProQuiz_pointsChartUser" class="wpProQuiz_pointsChart" aria-live="polite" data-chart-id="user-score" data-chart-title="<?php esc_attr_e( 'Tu Puntaje', 'villegas-courses' ); ?>" style="display: inline-flex; flex-direction: column; align-items: center; gap: 8px; margin: 1em 1em 1em 0;">
     <svg class="wpProQuiz_pointsChart__svg" viewBox="0 0 36 36" role="img" style="width: 120px; height: 120px;">
-        <circle class="wpProQuiz_pointsChart__track" cx="18" cy="18" r="16" fill="none" stroke="#f9c600" stroke-width="4"></circle>
+        <circle class="wpProQuiz_pointsChart__track" cx="18" cy="18" r="16" fill="none" stroke="#E3E3E3" stroke-width="4"></circle>
         <circle class="wpProQuiz_pointsChart__progress" cx="18" cy="18" r="16" fill="none" stroke="#f9c600" stroke-width="4" stroke-linecap="round" stroke-dasharray="0 100" stroke-dashoffset="25.12" transform="rotate(-90 18 18)"></circle>
     </svg>
     <div class="wpProQuiz_pointsChart__label" style="font-weight: 600;"></div>
@@ -140,7 +140,7 @@ array(
         <?php esc_html_e( 'Tu Puntaje', 'villegas-courses' ); ?>
     </div>
 </div>
-<div id="quiz-score-divider" style="display: inline-block; width: 1px; height: 140px; background-color: #E3E3E3; margin: 1em 0; vertical-align: middle;"></div>
+<div id="quiz-score-divider" style="display: inline-block; width: 1px; height: 240px; background-color: #E3E3E3; margin: 0 28px; vertical-align: middle;"></div>
 <?php if ( ! empty( $average_chart_markup ) ) : ?>
     <?php echo $average_chart_markup; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 <?php endif; ?>
@@ -228,6 +228,7 @@ if ( class_exists( 'CourseQuizMetaHelper' ) && $quiz_id ) {
     }
 }
 ?>
+<hr style="margin-bottom: 40px;">
 <table class="wpProQuiz_pointsChart__meta debug_table" style="text-align: center; font-size: 14px; display: none;">
     <tbody>
         <tr>

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -132,8 +132,8 @@ array(
 </p>
 <div id="wpProQuiz_pointsChartUser" class="wpProQuiz_pointsChart" aria-live="polite" data-chart-id="user-score" data-chart-title="<?php esc_attr_e( 'Tu Puntaje', 'villegas-courses' ); ?>" style="display: inline-flex; flex-direction: column; align-items: center; gap: 8px; margin: 1em 1em 1em 0;">
     <svg class="wpProQuiz_pointsChart__svg" viewBox="0 0 36 36" role="img" style="width: 120px; height: 120px;">
-        <circle class="wpProQuiz_pointsChart__track" cx="18" cy="18" r="16" fill="none" stroke="#E3E3E3" stroke-width="4"></circle>
-        <circle class="wpProQuiz_pointsChart__progress" cx="18" cy="18" r="16" fill="none" stroke="#4CAF50" stroke-width="4" stroke-linecap="round" stroke-dasharray="0 100" stroke-dashoffset="25.12" transform="rotate(-90 18 18)"></circle>
+        <circle class="wpProQuiz_pointsChart__track" cx="18" cy="18" r="16" fill="none" stroke="#f9c600" stroke-width="4"></circle>
+        <circle class="wpProQuiz_pointsChart__progress" cx="18" cy="18" r="16" fill="none" stroke="#f9c600" stroke-width="4" stroke-linecap="round" stroke-dasharray="0 100" stroke-dashoffset="25.12" transform="rotate(-90 18 18)"></circle>
     </svg>
     <div class="wpProQuiz_pointsChart__label" style="font-weight: 600;"></div>
     <div class="wpProQuiz_pointsChart__caption" style="font-size: 14px;">
@@ -282,7 +282,7 @@ if ( $is_enrolled_course && $course_url ) {
 if ( $button_label && $button_url ) :
     ?>
     <div style="text-align: center; margin-top: 12px;">
-        <a class="wpProQuiz_pointsChart__cta" href="<?php echo esc_url( $button_url ); ?>" style="display: inline-block; padding: 10px 20px; background-color: #4CAF50; color: #fff; border-radius: 4px; text-decoration: none; font-weight: 600;">
+        <a class="wpProQuiz_pointsChart__cta" href="<?php echo esc_url( $button_url ); ?>" style="display: inline-block; padding: 10px 20px; background-color: black; color: #fff; border-radius: 4px; text-decoration: none; font-weight: 600;">
             <?php echo esc_html( $button_label ); ?>
         </a>
     </div>


### PR DESCRIPTION
## Summary
- translate the quiz score labels to "Tu Puntaje" and "Puntaje Promedio"
- add a vertical divider element between the user and average score charts and adjust spacing

## Testing
- php -l templates/show_quiz_result_box.php
- php -l shortcodes/quiz-average-score-shortcode.php

------
https://chatgpt.com/codex/tasks/task_e_68e4fe8c7cd08332adbb1acabf2ae8bf