### PR TITLE
Implement automated Villegas quiz result emails

### DIFF
--- a/emails/final-quiz-email.php
+++ b/emails/final-quiz-email.php
@@ -3,60 +3,120 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/**
- * Build Final Quiz email content.
- *
- * @param array  $quiz_data Payload from learndash_quiz_completed.
- * @param object $user      WP_User object.
- * @param array  $debug     Debug data from Villegas_Quiz_Emails::get_quiz_debug_data().
- * @return array {subject, body}
- */
-function villegas_get_final_quiz_email_content( $quiz_data, $user, $debug ) {
-    $subject = sprintf( __( 'Your Final Quiz results for %s', 'villegas-courses' ), $debug['course_title'] );
+function villegas_get_final_quiz_email_content( array $quiz_data, WP_User $user ): array {
+    $debug = villegas_get_quiz_debug_data( $quiz_data, $user );
 
-    $first_percentage = intval( $debug['first_quiz_attempt'] );
-    $final_percentage = intval( $debug['final_quiz_attempt'] );
-    $delta            = $final_percentage - $first_percentage;
-
-    if ( $delta > 0 ) {
-        $progress_msg = sprintf( __( 'Congratulations! You improved by %d%% compared to your First Quiz.', 'villegas-courses' ), $delta );
-    } elseif ( $delta === 0 ) {
-        $progress_msg = __( 'Your score remained the same as your First Quiz.', 'villegas-courses' );
-    } else {
-        $progress_msg = sprintf( __( 'Your score decreased by %d%% compared to your First Quiz.', 'villegas-courses' ), abs( $delta ) );
+    if ( empty( $debug['is_final_quiz'] ) ) {
+        return [ 'subject' => '', 'body' => '' ];
     }
 
-    ob_start();
-    ?>
-    <html>
-    <body style="font-family: Arial, sans-serif; background:#f9f9f9; padding:20px;">
-        <div style="max-width:600px; margin:auto; background:#fff; padding:20px; border-radius:8px;">
-            <h2 style="color:#333;"><?php echo esc_html( $debug['user_display_name'] ); ?>,</h2>
-            <p><?php printf( __( 'You just completed the Final Quiz of %s.', 'villegas-courses' ), esc_html( $debug['course_title'] ) ); ?></p>
+    $course_title = $debug['course_title'];
 
-            <h3><?php esc_html_e( 'Your Results', 'villegas-courses' ); ?></h3>
-            <p><strong><?php esc_html_e( 'First Quiz:', 'villegas-courses' ); ?></strong>
-               <?php echo esc_html( $debug['first_quiz_attempt'] ); ?>
-               (<?php echo esc_html( $debug['first_quiz_date'] ); ?>)</p>
-            <p><strong><?php esc_html_e( 'Final Quiz:', 'villegas-courses' ); ?></strong>
-               <?php echo esc_html( $debug['final_quiz_attempt'] ); ?>
-               (<?php echo esc_html( $debug['final_quiz_date'] ); ?>)</p>
+    $first_score = isset( $debug['first_attempt']['percentage'] ) && null !== $debug['first_attempt']['percentage']
+        ? (float) $debug['first_attempt']['percentage']
+        : 0.0;
 
-            <p style="margin-top:15px; font-size:16px; color:#006600;">
-               <?php echo esc_html( $progress_msg ); ?>
-            </p>
+    $final_score = isset( $debug['final_attempt']['percentage'] ) && null !== $debug['final_attempt']['percentage']
+        ? (float) $debug['final_attempt']['percentage']
+        : 0.0;
 
-            <div style="margin-top:20px; text-align:center;">
-                <a href="<?php echo esc_url( get_permalink( $debug['course_id_detected'] ) ); ?>"
-                   style="background:#000; color:#fff; padding:12px 20px; text-decoration:none; border-radius:6px;">
-                   <?php esc_html_e( 'Browse Courses', 'villegas-courses' ); ?>
-                </a>
-            </div>
-        </div>
-    </body>
-    </html>
-    <?php
-    $body = ob_get_clean();
+    $first_timestamp = ! empty( $debug['first_attempt']['timestamp'] ) ? (int) $debug['first_attempt']['timestamp'] : null;
+    $final_timestamp = ! empty( $debug['final_attempt']['timestamp'] ) ? (int) $debug['final_attempt']['timestamp'] : current_time( 'timestamp' );
+
+    $first_date = $first_timestamp ? date_i18n( get_option( 'date_format' ), $first_timestamp ) : __( 'First Quiz pending', 'villegas-courses' );
+    $final_date = date_i18n( get_option( 'date_format' ), $final_timestamp );
+
+    $difference = round( $final_score ) - round( $first_score );
+
+    if ( $difference > 0 ) {
+        $progress_message = sprintf(
+            /* translators: %d: improvement in points. */
+            __( 'Wonderful! Your knowledge grew by %d points between quizzes.', 'villegas-courses' ),
+            $difference
+        );
+        $progress_color = '#1b873c';
+    } elseif ( 0 === $difference ) {
+        $progress_message = __( 'Your results are consistent — solid knowledge retained!', 'villegas-courses' );
+        $progress_color   = '#444444';
+    } else {
+        $progress_message = sprintf(
+            /* translators: %d: decrease in points. */
+            __( 'Your score decreased by %d points. Review the lessons and retake the quiz when you are ready.', 'villegas-courses' ),
+            abs( $difference )
+        );
+        $progress_color = '#b42323';
+    }
+
+    $subject = sprintf(
+        /* translators: %s: course title. */
+        __( '✔️ Final Quiz completed: %s', 'villegas-courses' ),
+        $course_title
+    );
+
+    $logo_url = '';
+
+    if ( function_exists( 'get_theme_mod' ) ) {
+        $logo_id = (int) get_theme_mod( 'custom_logo' );
+        if ( $logo_id ) {
+            $logo_src = wp_get_attachment_image_src( $logo_id, 'full' );
+            if ( $logo_src ) {
+                $logo_url = $logo_src[0];
+            }
+        }
+    }
+
+    if ( ! $logo_url ) {
+        $logo_url = get_site_icon_url( 192 );
+    }
+
+    $final_chart_url = villegas_generate_quickchart_url( $final_score );
+    $first_chart_url = villegas_generate_quickchart_url( $first_score );
+
+    $courses_url = home_url( '/courses/' );
+
+    $body  = '<div style="background-color:#f6f6f6;padding:32px 0;">';
+    $body .= '<div style="max-width:720px;margin:0 auto;background:#ffffff;border:1px solid #e5e5e5;border-radius:8px;font-family:Helvetica,Arial,sans-serif;color:#1c1c1c;">';
+
+    if ( $logo_url ) {
+        $body .= '<div style="text-align:center;padding:28px 24px 0;">';
+        $body .= '<img src="' . esc_url( $logo_url ) . '" alt="Villegas" style="max-width:220px;height:auto;">';
+        $body .= '</div>';
+    }
+
+    $body .= '<div style="padding:20px 48px 24px;text-align:center;">';
+    $body .= '<h1 style="margin:12px 0 8px;font-size:26px;color:#111111;">' . esc_html__( 'Congratulations!', 'villegas-courses' ) . '</h1>';
+    $body .= '<p style="margin:0;font-size:16px;line-height:1.5;">' . sprintf( esc_html__( 'You finished the course %s.', 'villegas-courses' ), esc_html( $course_title ) ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '<div style="padding:0 48px 24px;text-align:center;">';
+    $body .= '<p style="margin:0;font-size:15px;color:' . esc_attr( $progress_color ) . ';font-weight:600;">' . esc_html( $progress_message ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '<div style="display:flex;flex-wrap:wrap;gap:32px;justify-content:center;padding:0 48px 32px;border-top:1px solid #f1f1f1;border-bottom:1px solid #f1f1f1;">';
+
+    $body .= '<div style="text-align:center;min-width:220px;">';
+    $body .= '<h2 style="font-size:16px;margin-bottom:12px;color:#111111;">' . esc_html__( 'Final Quiz Result', 'villegas-courses' ) . '</h2>';
+    $body .= '<img src="' . esc_url( $final_chart_url ) . '" alt="' . esc_attr__( 'Final Quiz score', 'villegas-courses' ) . '" style="max-width:240px;height:auto;">';
+    $body .= '<p style="margin:12px 0 4px;font-size:18px;font-weight:600;color:#111111;">' . esc_html( number_format_i18n( round( $final_score ) ) ) . '%</p>';
+    $body .= '<p style="margin:0;font-size:13px;color:#6d6d6d;">' . sprintf( esc_html__( 'Completed on %s', 'villegas-courses' ), esc_html( $final_date ) ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '<div style="text-align:center;min-width:220px;">';
+    $body .= '<h2 style="font-size:16px;margin-bottom:12px;color:#111111;">' . esc_html__( 'First Quiz Result', 'villegas-courses' ) . '</h2>';
+    $body .= '<img src="' . esc_url( $first_chart_url ) . '" alt="' . esc_attr__( 'First Quiz score', 'villegas-courses' ) . '" style="max-width:240px;height:auto;">';
+    $body .= '<p style="margin:12px 0 4px;font-size:18px;font-weight:600;color:#111111;">' . esc_html( number_format_i18n( round( $first_score ) ) ) . '%</p>';
+    $body .= '<p style="margin:0;font-size:13px;color:#6d6d6d;">' . sprintf( esc_html__( 'Completed on %s', 'villegas-courses' ), esc_html( $first_date ) ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '</div>';
+
+    $body .= '<div style="padding:32px 48px;text-align:center;">';
+    $body .= '<p style="margin:0 0 18px;font-size:15px;color:#333333;">' . esc_html__( 'Keep your momentum! Explore more Villegas courses to continue learning.', 'villegas-courses' ) . '</p>';
+    $body .= '<a href="' . esc_url( $courses_url ) . '" style="display:inline-block;background:#000000;color:#ffffff;padding:14px 28px;border-radius:6px;text-decoration:none;font-weight:600;">' . esc_html__( 'Browse Courses', 'villegas-courses' ) . '</a>';
+    $body .= '</div>';
+
+    $body .= '</div>';
+    $body .= '</div>';
 
     return [
         'subject' => $subject,

--- a/emails/first-quiz-email.php
+++ b/emails/first-quiz-email.php
@@ -3,42 +3,127 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-/**
- * Build First Quiz email content.
- *
- * @param array  $quiz_data Payload from learndash_quiz_completed.
- * @param object $user      WP_User object.
- * @param array  $debug     Debug data from Villegas_Quiz_Emails::get_quiz_debug_data().
- * @return array {subject, body}
- */
-function villegas_get_first_quiz_email_content( $quiz_data, $user, $debug ) {
-    $subject = sprintf( __( 'You finished your First Quiz: %s', 'villegas-courses' ), $debug['quiz_title'] );
+function villegas_get_first_quiz_email_content( array $quiz_data, WP_User $user ): array {
+    $debug = villegas_get_quiz_debug_data( $quiz_data, $user );
 
-    ob_start();
-    ?>
-    <html>
-    <body style="font-family: Arial, sans-serif; background:#f9f9f9; padding:20px;">
-        <div style="max-width:600px; margin:auto; background:#fff; padding:20px; border-radius:8px;">
-            <h2 style="color:#333;"><?php echo esc_html( $debug['user_display_name'] ); ?>,</h2>
-            <p><?php printf( __( 'You just completed the First Quiz of %s.', 'villegas-courses' ), esc_html( $debug['course_title'] ) ); ?></p>
+    if ( empty( $debug['is_first_quiz'] ) ) {
+        return [ 'subject' => '', 'body' => '' ];
+    }
 
-            <p><strong><?php esc_html_e( 'Your Score:', 'villegas-courses' ); ?></strong>
-               <?php echo esc_html( $debug['first_quiz_attempt'] ); ?></p>
-            <p><em><?php echo esc_html( $debug['first_quiz_date'] ); ?></em></p>
+    $quiz_id   = $debug['quiz_id'];
+    $course_id = $debug['course_id'];
 
-            <p><?php esc_html_e( 'Great job! Continue the course to reinforce your knowledge.', 'villegas-courses' ); ?></p>
+    $user_score = isset( $debug['first_attempt']['percentage'] ) && null !== $debug['first_attempt']['percentage']
+        ? (float) $debug['first_attempt']['percentage']
+        : 0.0;
 
-            <div style="margin-top:20px; text-align:center;">
-                <a href="<?php echo esc_url( get_permalink( $debug['course_id_detected'] ) ); ?>"
-                   style="background:#000; color:#fff; padding:12px 20px; text-decoration:none; border-radius:6px;">
-                   <?php esc_html_e( 'Go to Course', 'villegas-courses' ); ?>
-                </a>
-            </div>
-        </div>
-    </body>
-    </html>
-    <?php
-    $body = ob_get_clean();
+    $average_score = null;
+
+    if ( $quiz_id ) {
+        $average_score = Villegas_Quiz_Stats::get_average_percentage( $quiz_id );
+    }
+
+    $average_value = null !== $average_score ? (float) $average_score : 0.0;
+
+    $subject = sprintf(
+        /* translators: %s: quiz title. */
+        __( '✔️ First Quiz completed: %s', 'villegas-courses' ),
+        $debug['quiz_title']
+    );
+
+    $completion_timestamp = ! empty( $debug['first_attempt']['timestamp'] ) ? (int) $debug['first_attempt']['timestamp'] : current_time( 'timestamp' );
+    $completion_date      = date_i18n( get_option( 'date_format' ), $completion_timestamp );
+
+    $course_url = $course_id ? get_permalink( $course_id ) : home_url( '/' );
+
+    $course_price_type = $course_id && function_exists( 'learndash_get_setting' )
+        ? learndash_get_setting( $course_id, 'course_price_type' )
+        : '';
+
+    $is_free_course = in_array( $course_price_type, [ 'free', 'open' ], true );
+    $has_access     = $course_id ? Villegas_Course::user_has_access( $course_id, $user->ID ) : false;
+
+    $button_label = __( 'Go to Course', 'villegas-courses' );
+    $button_url   = $course_url;
+    $button_note  = __( 'Continue with the lessons to prepare for the Final Quiz.', 'villegas-courses' );
+
+    if ( ! $is_free_course && ! $has_access ) {
+        $product_id = $course_id ? Villegas_Course::get_related_product_id( $course_id ) : 0;
+
+        if ( $product_id && function_exists( 'wc_get_checkout_url' ) ) {
+            $button_url = add_query_arg( 'add-to-cart', $product_id, wc_get_checkout_url() );
+        } elseif ( $product_id ) {
+            $button_url = get_permalink( $product_id );
+        } else {
+            $button_url = home_url( '/courses/' );
+        }
+
+        $button_label = __( 'Buy Course', 'villegas-courses' );
+        $button_note  = __( 'Purchase the course to unlock every lesson and the Final Quiz.', 'villegas-courses' );
+    }
+
+    $logo_url = '';
+
+    if ( function_exists( 'get_theme_mod' ) ) {
+        $logo_id = (int) get_theme_mod( 'custom_logo' );
+        if ( $logo_id ) {
+            $logo_src = wp_get_attachment_image_src( $logo_id, 'full' );
+            if ( $logo_src ) {
+                $logo_url = $logo_src[0];
+            }
+        }
+    }
+
+    if ( ! $logo_url ) {
+        $logo_url = get_site_icon_url( 192 );
+    }
+
+    $user_chart_url    = villegas_generate_quickchart_url( $user_score );
+    $average_chart_url = villegas_generate_quickchart_url( $average_value );
+
+    $average_caption = null !== $average_score
+        ? sprintf( __( 'Villegas average: %s%%', 'villegas-courses' ), number_format_i18n( round( $average_value ) ) )
+        : __( 'Villegas average: no attempts yet', 'villegas-courses' );
+
+    $body  = '<div style="background-color:#f6f6f6;padding:32px 0;">';
+    $body .= '<div style="max-width:720px;margin:0 auto;background:#ffffff;border:1px solid #e5e5e5;border-radius:8px;font-family:Helvetica,Arial,sans-serif;color:#1c1c1c;">';
+
+    if ( $logo_url ) {
+        $body .= '<div style="text-align:center;padding:28px 24px 0;">';
+        $body .= '<img src="' . esc_url( $logo_url ) . '" alt="Villegas" style="max-width:220px;height:auto;">';
+        $body .= '</div>';
+    }
+
+    $body .= '<div style="padding:20px 48px 32px;text-align:center;">';
+    $body .= '<p style="margin:0;font-size:12px;color:#6d6d6d;">' . sprintf( esc_html__( 'Completed on %s', 'villegas-courses' ), esc_html( $completion_date ) ) . '</p>';
+    $body .= '<h1 style="margin:12px 0 8px;font-size:26px;color:#111111;">' . sprintf( esc_html__( 'Great job, %s!', 'villegas-courses' ), esc_html( $debug['user_display_name'] ) ) . '</h1>';
+    $body .= '<p style="margin:0;font-size:16px;line-height:1.5;">' . sprintf( esc_html__( 'You completed the First Quiz of %s.', 'villegas-courses' ), esc_html( $debug['course_title'] ) ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '<div style="display:flex;flex-wrap:wrap;gap:32px;justify-content:center;padding:0 48px 32px;border-top:1px solid #f1f1f1;border-bottom:1px solid #f1f1f1;">';
+
+    $body .= '<div style="text-align:center;min-width:220px;">';
+    $body .= '<h2 style="font-size:16px;margin-bottom:12px;color:#111111;">' . esc_html__( 'Your Score', 'villegas-courses' ) . '</h2>';
+    $body .= '<img src="' . esc_url( $user_chart_url ) . '" alt="' . esc_attr__( 'Your score', 'villegas-courses' ) . '" style="max-width:240px;height:auto;">';
+    $body .= '<p style="margin-top:12px;font-size:18px;font-weight:600;color:#111111;">' . esc_html( number_format_i18n( round( $user_score ) ) ) . '%</p>';
+    $body .= '</div>';
+
+    $body .= '<div style="text-align:center;min-width:220px;">';
+    $body .= '<h2 style="font-size:16px;margin-bottom:12px;color:#111111;">' . esc_html__( 'Villegas Average', 'villegas-courses' ) . '</h2>';
+    $body .= '<img src="' . esc_url( $average_chart_url ) . '" alt="' . esc_attr__( 'Villegas average', 'villegas-courses' ) . '" style="max-width:240px;height:auto;">';
+    $body .= '<p style="margin-top:12px;font-size:15px;color:#444444;">' . esc_html( $average_caption ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '</div>';
+
+    $body .= '<div style="padding:32px 48px;text-align:center;">';
+    $body .= '<p style="margin:0 0 18px;font-size:15px;color:#333333;">' . esc_html__( 'Every lesson you finish will bring you closer to comparing your progress in the Final Quiz.', 'villegas-courses' ) . '</p>';
+    $body .= '<a href="' . esc_url( $button_url ) . '" style="display:inline-block;background:#000000;color:#ffffff;padding:14px 28px;border-radius:6px;text-decoration:none;font-weight:600;">' . esc_html( $button_label ) . '</a>';
+    $body .= '<p style="margin-top:16px;font-size:13px;color:#666666;">' . esc_html( $button_note ) . '</p>';
+    $body .= '</div>';
+
+    $body .= '</div>';
+    $body .= '</div>';
 
     return [
         'subject' => $subject,

--- a/functions.php
+++ b/functions.php
@@ -8,6 +8,12 @@ if ( ! class_exists( 'PoliteiaCourse' ) ) {
     require_once plugin_dir_path( __FILE__ ) . 'classes/class-politeia-course.php';
 }
 
+if ( ! class_exists( 'Villegas_Course' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'includes/class-villegas-course.php';
+}
+
+require_once plugin_dir_path( __FILE__ ) . 'includes/emails.php';
+
 function allow_pending_role_users_access_quiz( $has_access, $post_id, $user_id ) {
     // Get the user's role(s)
     $user = get_userdata( $user_id );

--- a/includes/class-villegas-course.php
+++ b/includes/class-villegas-course.php
@@ -1,0 +1,99 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Villegas_Course {
+    protected static function ensure_helper(): void {
+        if ( ! class_exists( 'CourseQuizMetaHelper' ) ) {
+            require_once plugin_dir_path( __FILE__ ) . '../classes/class-course-quiz-helper.php';
+        }
+    }
+
+    public static function get_course_from_quiz( int $quiz_id ): int {
+        self::ensure_helper();
+
+        $quiz_id = absint( $quiz_id );
+
+        if ( ! $quiz_id ) {
+            return 0;
+        }
+
+        return (int) CourseQuizMetaHelper::getCourseFromQuiz( $quiz_id );
+    }
+
+    public static function get_first_quiz_id( int $course_id ): int {
+        self::ensure_helper();
+
+        $course_id = absint( $course_id );
+
+        if ( ! $course_id ) {
+            return 0;
+        }
+
+        return (int) CourseQuizMetaHelper::getFirstQuizId( $course_id );
+    }
+
+    public static function get_final_quiz_id( int $course_id ): int {
+        self::ensure_helper();
+
+        $course_id = absint( $course_id );
+
+        if ( ! $course_id ) {
+            return 0;
+        }
+
+        return (int) CourseQuizMetaHelper::getFinalQuizId( $course_id );
+    }
+
+    public static function get_related_product_id( int $course_id ): int {
+        $course_id = absint( $course_id );
+
+        if ( ! $course_id ) {
+            return 0;
+        }
+
+        $product_id = get_post_meta( $course_id, '_linked_woocommerce_product', true );
+
+        if ( $product_id ) {
+            return (int) $product_id;
+        }
+
+        $products = get_posts(
+            [
+                'post_type'      => 'product',
+                'post_status'    => 'publish',
+                'meta_query'     => [
+                    [
+                        'key'     => '_related_course',
+                        'value'   => $course_id,
+                        'compare' => 'LIKE',
+                    ],
+                ],
+                'posts_per_page' => 1,
+                'fields'         => 'ids',
+            ]
+        );
+
+        return $products ? (int) $products[0] : 0;
+    }
+
+    public static function user_has_access( int $course_id, int $user_id ): bool {
+        $course_id = absint( $course_id );
+        $user_id   = absint( $user_id );
+
+        if ( ! $course_id || ! $user_id ) {
+            return false;
+        }
+
+        if ( function_exists( 'learndash_is_user_enrolled' ) ) {
+            return (bool) learndash_is_user_enrolled( $course_id, $user_id );
+        }
+
+        if ( function_exists( 'sfwd_lms_has_access' ) ) {
+            return (bool) sfwd_lms_has_access( $course_id, $user_id );
+        }
+
+        return false;
+    }
+}

--- a/includes/class-villegas-quiz-attempts-shortcode.php
+++ b/includes/class-villegas-quiz-attempts-shortcode.php
@@ -1,0 +1,36 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Villegas_Quiz_Stats' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-villegas-quiz-stats.php';
+}
+
+class Villegas_Quiz_Attempts_Shortcode {
+    public static $last_average = 0.0;
+
+    public static function render( $atts ): string {
+        $atts = shortcode_atts(
+            [
+                'id' => 0,
+            ],
+            $atts,
+            'villegas_quiz_attempts'
+        );
+
+        $quiz_id = absint( $atts['id'] );
+
+        if ( $quiz_id ) {
+            $average = Villegas_Quiz_Stats::get_average_percentage( $quiz_id );
+
+            if ( null !== $average ) {
+                self::$last_average = round( (float) $average, 2 );
+            }
+        }
+
+        return '';
+    }
+}
+
+add_shortcode( 'villegas_quiz_attempts', [ 'Villegas_Quiz_Attempts_Shortcode', 'render' ] );

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -1,0 +1,274 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Villegas_Course' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'class-villegas-course.php';
+}
+
+if ( ! class_exists( 'Villegas_Quiz_Attempts_Shortcode' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . 'class-villegas-quiz-attempts-shortcode.php';
+}
+
+if ( ! class_exists( 'Villegas_Quiz_Stats' ) ) {
+    require_once plugin_dir_path( __FILE__ ) . '../classes/class-villegas-quiz-stats.php';
+}
+
+if ( ! function_exists( 'villegas_generate_quickchart_url' ) ) {
+    function villegas_generate_quickchart_url( float $value ): string {
+        $value = max( 0, min( 100, round( $value, 2 ) ) );
+
+        $config = [
+            'type'    => 'doughnut',
+            'data'    => [
+                'datasets' => [
+                    [
+                        'data'            => [ $value, 100 - $value ],
+                        'backgroundColor' => [ '#f9c600', '#eeeeee' ],
+                        'borderWidth'     => 0,
+                    ],
+                ],
+            ],
+            'options' => [
+                'cutout'  => '10%',
+                'plugins' => [
+                    'legend'        => [ 'display' => false ],
+                    'tooltip'       => [ 'enabled' => false ],
+                    'datalabels'    => [ 'display' => false ],
+                    'doughnutlabel' => [
+                        'labels' => [
+                            [
+                                'text' => $value . '%',
+                                'font' => [
+                                    'size'   => 24,
+                                    'weight' => 'bold',
+                                ],
+                                'color' => '#333333',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'plugins' => [ 'doughnutlabel' ],
+        ];
+
+        return 'https://quickchart.io/chart?c=' . urlencode( wp_json_encode( $config ) );
+    }
+}
+
+if ( ! function_exists( 'villegas_get_latest_quiz_attempt' ) ) {
+    function villegas_get_latest_quiz_attempt( int $user_id, int $quiz_id ): array {
+        global $wpdb;
+
+        $user_id = absint( $user_id );
+        $quiz_id = absint( $quiz_id );
+
+        if ( ! $user_id || ! $quiz_id ) {
+            return [ 'percentage' => null, 'timestamp' => null ];
+        }
+
+        $activity_table = $wpdb->prefix . 'learndash_user_activity';
+        $meta_table     = $wpdb->prefix . 'learndash_user_activity_meta';
+
+        $attempt = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT ua.activity_id, ua.activity_completed
+                 FROM {$activity_table} AS ua
+                 INNER JOIN {$meta_table} AS quiz_meta
+                    ON quiz_meta.activity_id = ua.activity_id
+                   AND quiz_meta.activity_meta_key = 'quiz'
+                   AND quiz_meta.activity_meta_value+0 = %d
+                 WHERE ua.user_id = %d
+                   AND ua.activity_type = 'quiz'
+                   AND ua.activity_completed IS NOT NULL
+                 ORDER BY ua.activity_completed DESC
+                 LIMIT 1",
+                $quiz_id,
+                $user_id
+            ),
+            ARRAY_A
+        );
+
+        if ( empty( $attempt ) || empty( $attempt['activity_id'] ) ) {
+            return [ 'percentage' => null, 'timestamp' => null ];
+        }
+
+        $percentage = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT activity_meta_value+0
+                 FROM {$meta_table}
+                 WHERE activity_id = %d
+                   AND activity_meta_key = 'percentage'
+                 LIMIT 1",
+                (int) $attempt['activity_id']
+            )
+        );
+
+        return [
+            'percentage' => is_numeric( $percentage ) ? (float) $percentage : null,
+            'timestamp'  => ! empty( $attempt['activity_completed'] ) ? (int) $attempt['activity_completed'] : null,
+        ];
+    }
+}
+
+if ( ! function_exists( 'villegas_get_quiz_debug_data' ) ) {
+    function villegas_get_quiz_debug_data( array $quiz_data, WP_User $user ): array {
+        $quiz_id = isset( $quiz_data['quiz'] ) ? $quiz_data['quiz'] : 0;
+
+        if ( $quiz_id instanceof WP_Post ) {
+            $quiz_id = $quiz_id->ID;
+        }
+
+        $quiz_id = absint( $quiz_id );
+        $user_id = absint( $user->ID );
+
+        $course_id = 0;
+
+        if ( $quiz_id ) {
+            $course_id = Villegas_Course::get_course_from_quiz( $quiz_id );
+
+            if ( ! $course_id && function_exists( 'learndash_get_course_id' ) ) {
+                $course_id = (int) learndash_get_course_id( $quiz_id );
+            }
+        }
+
+        $first_quiz_id = $course_id ? Villegas_Course::get_first_quiz_id( $course_id ) : 0;
+        $final_quiz_id = $course_id ? Villegas_Course::get_final_quiz_id( $course_id ) : 0;
+
+        $is_first_quiz = $quiz_id && $first_quiz_id && (int) $quiz_id === (int) $first_quiz_id;
+        $is_final_quiz = $quiz_id && $final_quiz_id && (int) $quiz_id === (int) $final_quiz_id;
+
+        $first_attempt = $first_quiz_id ? villegas_get_latest_quiz_attempt( $user_id, $first_quiz_id ) : [ 'percentage' => null, 'timestamp' => null ];
+        $final_attempt = $final_quiz_id ? villegas_get_latest_quiz_attempt( $user_id, $final_quiz_id ) : [ 'percentage' => null, 'timestamp' => null ];
+
+        $current_percentage = isset( $quiz_data['percentage'] ) && is_numeric( $quiz_data['percentage'] )
+            ? (float) $quiz_data['percentage']
+            : null;
+
+        if ( $is_first_quiz && null !== $current_percentage ) {
+            $first_attempt['percentage'] = $current_percentage;
+            $first_attempt['timestamp']  = $first_attempt['timestamp'] ?: time();
+        }
+
+        if ( $is_final_quiz && null !== $current_percentage ) {
+            $final_attempt['percentage'] = $current_percentage;
+            $final_attempt['timestamp']  = $final_attempt['timestamp'] ?: time();
+        }
+
+        return [
+            'quiz_id'             => $quiz_id,
+            'quiz_title'          => $quiz_id ? get_the_title( $quiz_id ) : '',
+            'course_id'           => $course_id,
+            'course_title'        => $course_id ? get_the_title( $course_id ) : '',
+            'first_quiz_id'       => $first_quiz_id,
+            'final_quiz_id'       => $final_quiz_id,
+            'is_first_quiz'       => $is_first_quiz,
+            'is_final_quiz'       => $is_final_quiz,
+            'first_attempt'       => $first_attempt,
+            'final_attempt'       => $final_attempt,
+            'user_id'             => $user_id,
+            'user_display_name'   => $user->display_name,
+            'user_email'          => $user->user_email,
+            'current_percentage'  => $current_percentage,
+        ];
+    }
+}
+
+require_once plugin_dir_path( __FILE__ ) . '../emails/first-quiz-email.php';
+require_once plugin_dir_path( __FILE__ ) . '../emails/final-quiz-email.php';
+
+if ( ! function_exists( 'villegas_quiz_completed_handler' ) ) {
+    function villegas_quiz_completed_handler( $quiz_data, $user ) {
+        if ( ! ( $user instanceof WP_User ) ) {
+            return;
+        }
+
+        $debug = villegas_get_quiz_debug_data( $quiz_data, $user );
+
+        if ( $debug['is_first_quiz'] ) {
+            $email = villegas_get_first_quiz_email_content( $quiz_data, $user );
+        } elseif ( $debug['is_final_quiz'] ) {
+            $email = villegas_get_final_quiz_email_content( $quiz_data, $user );
+        } else {
+            return;
+        }
+
+        if ( empty( $email['subject'] ) || empty( $email['body'] ) ) {
+            return;
+        }
+
+        $admin_email = get_option( 'admin_email' );
+
+        if ( ! $admin_email ) {
+            return;
+        }
+
+        wp_mail(
+            $admin_email,
+            $email['subject'],
+            $email['body'],
+            [ 'Content-Type: text/html; charset=UTF-8' ]
+        );
+    }
+}
+add_action( 'learndash_quiz_completed', 'villegas_quiz_completed_handler', 10, 2 );
+
+if ( ! function_exists( 'villegas_send_first_quiz_email_handler' ) ) {
+    function villegas_send_first_quiz_email_handler() {
+        $nonce = isset( $_POST['nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : '';
+
+        if ( ! wp_verify_nonce( $nonce, 'villegas_send_first_quiz_email' ) ) {
+            wp_send_json_error( 'invalid_nonce', 403 );
+        }
+
+        $quiz_id      = isset( $_POST['quiz_id'] ) ? (int) $_POST['quiz_id'] : 0;
+        $user_id      = isset( $_POST['user_id'] ) ? (int) $_POST['user_id'] : 0;
+        $percentage   = isset( $_POST['quiz_percentage'] ) ? (float) $_POST['quiz_percentage'] : null;
+        $current_user = get_current_user_id();
+
+        if ( ! $quiz_id || ! $user_id ) {
+            wp_send_json_error( 'missing_parameters', 400 );
+        }
+
+        if ( $current_user && $current_user !== $user_id && ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'forbidden', 403 );
+        }
+
+        if ( ! is_user_logged_in() ) {
+            wp_send_json_error( 'not_logged_in', 403 );
+        }
+
+        $user = get_userdata( $user_id );
+
+        if ( ! $user ) {
+            wp_send_json_error( 'user_not_found', 404 );
+        }
+
+        $quiz_data = [
+            'quiz'       => $quiz_id,
+            'percentage' => $percentage,
+        ];
+
+        $email = villegas_get_first_quiz_email_content( $quiz_data, $user );
+
+        if ( empty( $email['subject'] ) || empty( $email['body'] ) ) {
+            wp_send_json_error( 'empty_email', 500 );
+        }
+
+        $sent = wp_mail(
+            $user->user_email,
+            $email['subject'],
+            $email['body'],
+            [ 'Content-Type: text/html; charset=UTF-8' ]
+        );
+
+        if ( $sent ) {
+            wp_send_json_success( 'email_sent' );
+        }
+
+        wp_send_json_error( 'mail_failed', 500 );
+    }
+}
+add_action( 'wp_ajax_villegas_send_first_quiz_email', 'villegas_send_first_quiz_email_handler' );
+add_action( 'wp_ajax_nopriv_villegas_send_first_quiz_email', 'villegas_send_first_quiz_email_handler' );

--- a/templates/show_quiz_result_box.php
+++ b/templates/show_quiz_result_box.php
@@ -111,6 +111,10 @@ if ( ! $quiz->isHideResultPoints() ) {
     $average_chart_markup = '';
 
     if ( $quiz_id ) {
+        if ( shortcode_exists( 'villegas_quiz_attempts' ) ) {
+            do_shortcode( sprintf( '[villegas_quiz_attempts id="%d"]', $quiz_id ) );
+        }
+
         $average_chart_markup = do_shortcode( sprintf( '[villegas_quiz_average_score quiz_id="%d" title="%s"]', $quiz_id, esc_attr__( 'Puntaje Promedio', 'villegas-courses' ) ) );
     }
 ?>


### PR DESCRIPTION
## Summary
- add a dedicated email orchestration layer that hooks into LearnDash quiz completion and AJAX for first-quiz notifications
- build QuickChart-powered First/Final Quiz email templates with CTA logic based on course access and WooCommerce linkage
- introduce course/helper utilities and refresh quiz result scripts/templates so averages match between UI and email content

## Testing
- php -l includes/emails.php
- php -l emails/first-quiz-email.php
- php -l emails/final-quiz-email.php
- php -l my-ld-course-override.php
- php -l templates/show_quiz_result_box.php

------
https://chatgpt.com/codex/tasks/task_e_68e673c8bb0c83328e188a0833cbecc7